### PR TITLE
Fix build: add missing FileSystem kind field + add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+tc (Topology Composer) is a Rust CLI tool for defining and deploying serverless topologies. It is a single binary built from a Cargo workspace with 19 library crates under `lib/`.
+
+### Build & Run
+
+- **Rust 1.90+** is required (edition 2024). The default VM toolchain is too old; the update script installs 1.90 automatically.
+- Build: `RUSTUP_TOOLCHAIN=1.90 cargo build` (or `make build`, though the Makefile's `cp` step assumes `TARGET_DIR=$(HOME)/.cargo/target` which may not match `cargo`'s actual target directory — the binary is at `target/debug/tc`).
+- The binary is at `./target/debug/tc` after a debug build.
+- OpenSSL is compiled from source via the `vendored` feature; no system `libssl-dev` is needed, but `perl` must be available.
+
+### Testing
+
+- Unit tests: `cargo test --quiet -j 2 -- --test-threads=2` (see `make unit-test`).
+- Integration tests: `cargo test --test integration_test --quiet` (requires AWS credentials).
+- Format check: `cargo +nightly fmt --check` (requires nightly toolchain installed).
+
+### Offline commands (no AWS needed)
+
+These tc subcommands work without AWS credentials and are useful for smoke-testing:
+- `tc compile` — compile a topology spec from a `topology.yml`
+- `tc compose` — compose a topology into provider-specific output
+- `tc visualize` — generate an HTML flow diagram
+- `tc version` — print version
+
+Run from a directory containing a `topology.yml`, e.g.: `cd examples/composition/route-function && ./target/debug/tc compile`
+
+### AWS-dependent commands
+
+`create`, `update`, `delete`, `invoke`, `list`, `resolve`, `deploy`, `snapshot`, `route`, `freeze`, `unfreeze`, `prune` all require valid AWS credentials configured in the environment.
+
+### Known issues on main
+
+- The `Makefile` `build` target copies the binary from `$(HOME)/.cargo/target/debug/tc`, but Cargo's actual target directory defaults to `./target/`. The `cp` step may fail; use `cargo build` directly and reference `./target/debug/tc`.
+- `cargo clippy` reports pre-existing errors in `compiler` crate; the project does not gate on clippy in CI.

--- a/lib/resolver/src/function.rs
+++ b/lib/resolver/src/function.rs
@@ -3,6 +3,7 @@ use compiler::{
     TopologyKind,
     spec::InfraSpec,
 };
+use compiler::spec::function::FileSystemKind;
 use composer::{
     Function,
     Runtime,
@@ -177,6 +178,7 @@ async fn resolve_fs(ctx: &Context, fs: Option<FileSystem>) -> Option<FileSystem>
             match arn {
                 Some(a) => {
                     let fs = FileSystem {
+                        kind: FileSystemKind::Efs,
                         arn: a,
                         mount_point: config.aws.lambda.fs_mountpoint.to_owned(),
                     };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The latest commit on `main` (`e7a1eb0 Adds fs option to functionspec`) added a `kind` field to the `FileSystem` struct in the composer crate but did not update the resolver's construction of `FileSystem`, causing a compilation failure on `main`.

### Changes

- **`lib/resolver/src/function.rs`**: Added the missing `kind: FileSystemKind::Efs` field to `FileSystem` initialization, and imported `FileSystemKind`. This defaults to EFS since the resolver creates `FileSystem` from EFS access points.
- **`AGENTS.md`**: Added Cursor Cloud specific development instructions covering build, test, offline/online commands, and known issues.

### Development Environment Verification

The following were verified as working:

- Build: `RUSTUP_TOOLCHAIN=1.90 cargo build`
- Unit tests: `cargo test --quiet -j 2 -- --test-threads=2`
- Format check: `cargo +nightly fmt --check`
- CLI commands: `tc version`, `tc compile`, `tc compose`, `tc visualize`

[tc_demo_output.log](https://cursor.com/agents/bc-d3cf0eb8-703a-4c3e-829b-cef48b1dfa41/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftc_demo_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3cf0eb8-703a-4c3e-829b-cef48b1dfa41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3cf0eb8-703a-4c3e-829b-cef48b1dfa41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

