### PR TITLE
Detect code-dep changes across symlinks and manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,6 +1845,7 @@ dependencies = [
  "nom 7.1.3",
  "ptree",
  "rand 0.8.5",
+ "rayon",
  "regex",
  "semver 0.7.0",
  "serde 1.0.228",
@@ -2019,6 +2020,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4955638f00a809894c947f85a024020a20815b65a5eea633798ea7924edab2b3"
 dependencies = [
  "crc",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2225,7 +2245,9 @@ dependencies = [
  "serde_json",
  "tabled 0.10.0",
  "tagger",
+ "tempfile",
  "tracing",
+ "walkdir",
 ]
 
 [[package]]
@@ -4457,6 +4479,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,7 +1845,6 @@ dependencies = [
  "nom 7.1.3",
  "ptree",
  "rand 0.8.5",
- "rayon",
  "regex",
  "semver 0.7.0",
  "serde 1.0.228",
@@ -2020,25 +2019,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4955638f00a809894c947f85a024020a20815b65a5eea633798ea7924edab2b3"
 dependencies = [
  "crc",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -4479,26 +4459,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/lib/compiler/src/spec/function.rs
+++ b/lib/compiler/src/spec/function.rs
@@ -414,12 +414,25 @@ pub struct FunctionSpec {
 }
 
 fn find_revision(dir: &str) -> String {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+    static CACHE: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(guard) = cache.lock() {
+        if let Some(v) = guard.get(dir) {
+            return v.clone();
+        }
+    }
     let cmd_str = format!("git log -n 1 --format=%h {}", dir);
-    u::sh(&cmd_str, dir)
+    let v = u::sh(&cmd_str, dir);
+    if let Ok(mut guard) = cache.lock() {
+        guard.insert(dir.to_string(), v.clone());
+    }
+    v
 }
 
 fn top_level() -> String {
-    u::sh("git rev-parse --show-toplevel", &u::pwd())
+    u::root()
 }
 
 fn render(s: &str, version: &str) -> String {

--- a/lib/composer/Cargo.toml
+++ b/lib/composer/Cargo.toml
@@ -25,6 +25,7 @@ base64 = "0.21.0"
 anyhow = "1.0.71"
 serde_with = "3.14.0"
 itertools = "0.10.5"
+rayon = "1.10"
 kit = { path = "../kit" }
 configurator = { path = "../configurator" }
 compiler = { path = "../compiler" }

--- a/lib/composer/Cargo.toml
+++ b/lib/composer/Cargo.toml
@@ -25,7 +25,6 @@ base64 = "0.21.0"
 anyhow = "1.0.71"
 serde_with = "3.14.0"
 itertools = "0.10.5"
-rayon = "1.10"
 kit = { path = "../kit" }
 configurator = { path = "../configurator" }
 compiler = { path = "../compiler" }

--- a/lib/composer/src/topology.rs
+++ b/lib/composer/src/topology.rs
@@ -296,18 +296,41 @@ fn discover_functions(
     infra_dir: &str,
     spec: &TopologySpec,
 ) -> HashMap<String, Function> {
-    use rayon::prelude::*;
-    let dirs = function_dirs(dir);
-    let fmt = spec.fmt();
-    let name = spec.name.clone();
-    dirs.par_iter()
+    let dirs: Vec<String> = function_dirs(dir)
+        .into_iter()
         .filter(|d| u::is_dir(d) && !ignore_function(d, dir))
-        .map(|d| {
-            tracing::debug!("function {}", d);
-            let function = Function::new(d, infra_dir, &name, &fmt);
-            (function.name.clone(), function)
-        })
-        .collect()
+        .collect();
+    if dirs.is_empty() {
+        return HashMap::new();
+    }
+
+    let name = spec.name.clone();
+    let fmt = spec.fmt();
+    let threads = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4)
+        .min(dirs.len());
+    let chunk_size = dirs.len().div_ceil(threads);
+
+    std::thread::scope(|s| {
+        dirs.chunks(chunk_size)
+            .map(|chunk| {
+                s.spawn(|| {
+                    chunk
+                        .iter()
+                        .map(|d| {
+                            tracing::debug!("function {}", d);
+                            let f = Function::new(d, infra_dir, &name, &fmt);
+                            (f.name.clone(), f)
+                        })
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .flat_map(|h| h.join().unwrap())
+            .collect()
+    })
 }
 
 fn current_function(dir: &str, infra_dir: &str, spec: &TopologySpec) -> HashMap<String, Function> {
@@ -382,7 +405,6 @@ fn discover_leaf_nodes(
 // builders
 
 fn make_nodes(root_dir: &str, spec: &TopologySpec) -> HashMap<String, Topology> {
-    use rayon::prelude::*;
     let ignore_nodes = &spec.nodes.ignore;
     let candidates: Vec<String> = WalkDir::new(root_dir)
         .follow_links(false)
@@ -393,22 +415,44 @@ fn make_nodes(root_dir: &str, spec: &TopologySpec) -> HashMap<String, Topology> 
         .filter(|p| is_topology_dir(p) && root_dir != p)
         .filter(|p| !should_ignore_node(root_dir, ignore_nodes.clone(), p))
         .collect();
+    if candidates.is_empty() {
+        return HashMap::new();
+    }
 
-    candidates
-        .par_iter()
-        .map(|p| {
-            let f = format!("{}/topology.yml", &p);
-            let node_spec = TopologySpec::new(&f);
-            tracing::debug!("node {}", &node_spec.name);
-            let infra_dir = as_infra_dir(node_spec.infra.to_owned(), p);
-            let mut functions = discover_functions(p, &infra_dir, &node_spec);
-            let interned = intern_functions(p, &infra_dir, &node_spec);
-            functions.extend(interned);
-            let leaf_nodes = discover_leaf_nodes(&node_spec.name, root_dir, p, &node_spec);
-            let node = make(root_dir, p, &node_spec, functions, leaf_nodes);
-            (node_spec.name.to_string(), node)
-        })
-        .collect()
+    let threads = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4)
+        .min(candidates.len());
+    let chunk_size = candidates.len().div_ceil(threads);
+
+    std::thread::scope(|s| {
+        candidates
+            .chunks(chunk_size)
+            .map(|chunk| {
+                s.spawn(|| {
+                    chunk
+                        .iter()
+                        .map(|p| {
+                            let f = format!("{}/topology.yml", &p);
+                            let node_spec = TopologySpec::new(&f);
+                            tracing::debug!("node {}", &node_spec.name);
+                            let infra_dir = as_infra_dir(node_spec.infra.to_owned(), p);
+                            let mut functions = discover_functions(p, &infra_dir, &node_spec);
+                            let interned = intern_functions(p, &infra_dir, &node_spec);
+                            functions.extend(interned);
+                            let leaf_nodes =
+                                discover_leaf_nodes(&node_spec.name, root_dir, p, &node_spec);
+                            let node = make(root_dir, p, &node_spec, functions, leaf_nodes);
+                            (node_spec.name.to_string(), node)
+                        })
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .flat_map(|h| h.join().unwrap())
+            .collect()
+    })
 }
 
 fn make_events(

--- a/lib/composer/src/topology.rs
+++ b/lib/composer/src/topology.rs
@@ -291,6 +291,22 @@ fn ignore_function(dir: &str, root_dir: &str) -> bool {
     }
 }
 
+fn discover_functions_sequential(
+    dir: &str,
+    infra_dir: &str,
+    spec: &TopologySpec,
+) -> HashMap<String, Function> {
+    function_dirs(dir)
+        .into_iter()
+        .filter(|d| u::is_dir(d) && !ignore_function(d, dir))
+        .map(|d| {
+            tracing::debug!("function {}", d);
+            let f = Function::new(&d, infra_dir, &spec.name, spec.fmt());
+            (f.name.clone(), f)
+        })
+        .collect()
+}
+
 fn discover_functions(
     dir: &str,
     infra_dir: &str,
@@ -437,7 +453,8 @@ fn make_nodes(root_dir: &str, spec: &TopologySpec) -> HashMap<String, Topology> 
                             let node_spec = TopologySpec::new(&f);
                             tracing::debug!("node {}", &node_spec.name);
                             let infra_dir = as_infra_dir(node_spec.infra.to_owned(), p);
-                            let mut functions = discover_functions(p, &infra_dir, &node_spec);
+                            let mut functions =
+                                discover_functions_sequential(p, &infra_dir, &node_spec);
                             let interned = intern_functions(p, &infra_dir, &node_spec);
                             functions.extend(interned);
                             let leaf_nodes =

--- a/lib/composer/src/topology.rs
+++ b/lib/composer/src/topology.rs
@@ -296,17 +296,18 @@ fn discover_functions(
     infra_dir: &str,
     spec: &TopologySpec,
 ) -> HashMap<String, Function> {
-    let mut functions: HashMap<String, Function> = HashMap::new();
+    use rayon::prelude::*;
     let dirs = function_dirs(dir);
-
-    for d in dirs {
-        tracing::debug!("function {}", d);
-        if u::is_dir(&d) && !ignore_function(&d, dir) {
-            let function = Function::new(&d, infra_dir, &spec.name, spec.fmt());
-            functions.insert(function.name.clone(), function);
-        }
-    }
-    functions
+    let fmt = spec.fmt();
+    let name = spec.name.clone();
+    dirs.par_iter()
+        .filter(|d| u::is_dir(d) && !ignore_function(d, dir))
+        .map(|d| {
+            tracing::debug!("function {}", d);
+            let function = Function::new(d, infra_dir, &name, &fmt);
+            (function.name.clone(), function)
+        })
+        .collect()
 }
 
 fn current_function(dir: &str, infra_dir: &str, spec: &TopologySpec) -> HashMap<String, Function> {
@@ -381,31 +382,33 @@ fn discover_leaf_nodes(
 // builders
 
 fn make_nodes(root_dir: &str, spec: &TopologySpec) -> HashMap<String, Topology> {
+    use rayon::prelude::*;
     let ignore_nodes = &spec.nodes.ignore;
-    let mut nodes: HashMap<String, Topology> = HashMap::new();
-    for entry in WalkDir::new(root_dir)
+    let candidates: Vec<String> = WalkDir::new(root_dir)
         .follow_links(false)
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| e.file_type().is_dir())
-    {
-        let p = entry.path().to_string_lossy();
-        if is_topology_dir(&p) && root_dir != p.clone() {
-            if !should_ignore_node(root_dir, ignore_nodes.clone(), &p) {
-                let f = format!("{}/topology.yml", &p);
-                let spec = TopologySpec::new(&f);
-                tracing::debug!("node {}", &spec.name);
-                let infra_dir = as_infra_dir(spec.infra.to_owned(), &p);
-                let mut functions = discover_functions(&p, &infra_dir, &spec);
-                let interned = intern_functions(&p, &infra_dir, &spec);
-                functions.extend(interned);
-                let leaf_nodes = discover_leaf_nodes(&spec.name, root_dir, &p, &spec);
-                let node = make(root_dir, &p, &spec, functions, leaf_nodes);
-                nodes.insert(spec.name.to_string(), node);
-            }
-        }
-    }
-    nodes
+        .map(|e| e.path().to_string_lossy().to_string())
+        .filter(|p| is_topology_dir(p) && root_dir != p)
+        .filter(|p| !should_ignore_node(root_dir, ignore_nodes.clone(), p))
+        .collect();
+
+    candidates
+        .par_iter()
+        .map(|p| {
+            let f = format!("{}/topology.yml", &p);
+            let node_spec = TopologySpec::new(&f);
+            tracing::debug!("node {}", &node_spec.name);
+            let infra_dir = as_infra_dir(node_spec.infra.to_owned(), p);
+            let mut functions = discover_functions(p, &infra_dir, &node_spec);
+            let interned = intern_functions(p, &infra_dir, &node_spec);
+            functions.extend(interned);
+            let leaf_nodes = discover_leaf_nodes(&node_spec.name, root_dir, p, &node_spec);
+            let node = make(root_dir, p, &node_spec, functions, leaf_nodes);
+            (node_spec.name.to_string(), node)
+        })
+        .collect()
 }
 
 fn make_events(

--- a/lib/differ/Cargo.toml
+++ b/lib/differ/Cargo.toml
@@ -11,6 +11,10 @@ regex = "1.9.1"
 tracing = "0.1"
 cacache = "13.0.0"
 tabled = "0.10.0"
+walkdir = "2"
 kit = { path = "../kit" }
 composer = { path = "../composer" }
 tagger = { path = "../tagger" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/lib/differ/src/deps.rs
+++ b/lib/differ/src/deps.rs
@@ -1,0 +1,505 @@
+//! Per-function code-dependency closure computation with shared caching.
+//!
+//! The core data structure is [`Analyzer`]: a cache of directory →
+//! "outgoing refs" (symlink targets + manifest path-dep resolutions). Every
+//! unique directory in the repo is walked at most once per `Analyzer`
+//! lifetime, regardless of how many functions include it in their closure.
+//! For a topology where 100 functions all symlink to the same `shared_lib`,
+//! `shared_lib` is walked exactly once.
+//!
+//! A function's closure is a BFS over the directed graph whose edges are
+//! these cached refs, starting from `f.dir`. The returned [`Closure`] is a
+//! small set of "walked-root" directories (any descendant file matches) and
+//! a small set of extra file paths (exact match for individual
+//! symlinked-file targets).
+
+use crate::manifest;
+use std::cell::RefCell;
+use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+/// Upper bound on symlink-chain depth. Defensive against pathological
+/// chains or disk corruption.
+const MAX_SYMLINK_DEPTH: usize = 16;
+
+/// Outgoing edges from a single directory: other dirs / files it depends
+/// on. Does NOT include descendant subdirs walked during the directory's
+/// own walk — those are covered implicitly by the fact that this dir is a
+/// closure root.
+#[derive(Debug, Default, Clone)]
+struct Refs {
+    dirs: Vec<PathBuf>,
+    files: Vec<PathBuf>,
+}
+
+/// Final result of a per-function closure computation.
+#[derive(Debug, Default, Clone)]
+pub struct Closure {
+    /// Walked-root canonical dirs. Any descendant file under any of these
+    /// is considered part of the closure.
+    pub roots: BTreeSet<PathBuf>,
+    /// Extra absolute canonical file paths (e.g. a symlink target that
+    /// is a single file).
+    pub files: BTreeSet<PathBuf>,
+}
+
+impl Closure {
+    /// Returns true iff `abs_path` is under any root in the closure or
+    /// exactly equal to one of the extra files.
+    pub fn contains(&self, abs_path: &Path) -> bool {
+        if self.files.contains(abs_path) {
+            return true;
+        }
+        for r in &self.roots {
+            if abs_path.starts_with(r) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// Cross-function cache. One instance per diff invocation.
+pub struct Analyzer {
+    repo_root: PathBuf,
+    refs: RefCell<HashMap<PathBuf, Refs>>,
+}
+
+impl Analyzer {
+    /// Construct with `repo_root`. The root is canonicalized once up-front.
+    /// Returns `None` if `repo_root` cannot be canonicalized.
+    pub fn new(repo_root: &Path) -> Option<Self> {
+        let canonical = repo_root.canonicalize().ok()?;
+        Some(Self {
+            repo_root: canonical,
+            refs: RefCell::new(HashMap::new()),
+        })
+    }
+
+    pub fn repo_root(&self) -> &Path {
+        &self.repo_root
+    }
+
+    /// Compute the closure of `fn_dir`. If the dir doesn't exist or is
+    /// outside the repo, returns an empty closure.
+    pub fn closure(&self, fn_dir: &Path) -> Closure {
+        let seed = match self.canonicalize_within(fn_dir) {
+            Some(s) => s,
+            None => return Closure::default(),
+        };
+
+        let mut roots: BTreeSet<PathBuf> = BTreeSet::new();
+        let mut files: BTreeSet<PathBuf> = BTreeSet::new();
+        let mut queue: VecDeque<PathBuf> = VecDeque::new();
+        queue.push_back(seed);
+
+        while let Some(d) = queue.pop_front() {
+            if !roots.insert(d.clone()) {
+                continue;
+            }
+            let refs = self.refs_for(&d);
+            for nd in &refs.dirs {
+                if !roots.contains(nd) {
+                    queue.push_back(nd.clone());
+                }
+            }
+            for f in &refs.files {
+                files.insert(f.clone());
+            }
+        }
+
+        Closure { roots, files }
+    }
+
+    /// Canonicalize `p` and confirm it's inside `repo_root`. Returns None
+    /// if it doesn't exist or escapes the repo.
+    fn canonicalize_within(&self, p: &Path) -> Option<PathBuf> {
+        let c = p.canonicalize().ok()?;
+        if c.starts_with(&self.repo_root) {
+            Some(c)
+        } else {
+            None
+        }
+    }
+
+    /// Get the cached refs for `dir`, populating the cache if needed.
+    fn refs_for(&self, dir: &Path) -> Refs {
+        if let Some(r) = self.refs.borrow().get(dir) {
+            return r.clone();
+        }
+        let r = self.walk_and_extract(dir);
+        self.refs.borrow_mut().insert(dir.to_path_buf(), r.clone());
+        r
+    }
+
+    fn walk_and_extract(&self, dir: &Path) -> Refs {
+        let mut dirs: Vec<PathBuf> = Vec::new();
+        let mut files: Vec<PathBuf> = Vec::new();
+        let mut manifests: Vec<PathBuf> = Vec::new();
+
+        for entry in WalkDir::new(dir)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            let ft = entry.file_type();
+
+            if ft.is_symlink() {
+                if let Some(target) = resolve_symlink_chain(path, &self.repo_root) {
+                    match fs::metadata(&target) {
+                        Ok(meta) if meta.is_dir() => dirs.push(target),
+                        Ok(meta) if meta.is_file() => files.push(target),
+                        Ok(_) => {}
+                        Err(e) => tracing::warn!(
+                            "symlink {} resolved to unreadable target {}: {}",
+                            path.display(),
+                            target.display(),
+                            e
+                        ),
+                    }
+                }
+            } else if ft.is_file() {
+                if let Some(name) = path.file_name().and_then(|s| s.to_str()) {
+                    if manifest::is_manifest(name) {
+                        manifests.push(path.to_path_buf());
+                    }
+                }
+            }
+        }
+
+        for m in &manifests {
+            for target in resolve_manifest_refs(m, &self.repo_root) {
+                match fs::metadata(&target) {
+                    Ok(meta) if meta.is_dir() => dirs.push(target),
+                    Ok(meta) if meta.is_file() => files.push(target),
+                    _ => {}
+                }
+            }
+        }
+
+        dirs.sort();
+        dirs.dedup();
+        files.sort();
+        files.dedup();
+        Refs { dirs, files }
+    }
+}
+
+/// Convenience wrapper: build an Analyzer and compute a single closure.
+/// Use the long-lived `Analyzer` directly when computing closures for
+/// many functions — cross-function caching depends on it.
+pub fn compute_closure(fn_dir: &Path, repo_root: &Path) -> Closure {
+    match Analyzer::new(repo_root) {
+        Some(a) => a.closure(fn_dir),
+        None => Closure::default(),
+    }
+}
+
+/// Resolve `symlink_path` through any chain, returning the canonical target
+/// if it lives inside `repo_root` (already canonicalized). Warns and
+/// returns None on chain-too-deep, broken link, or off-repo target.
+fn resolve_symlink_chain(symlink_path: &Path, repo_root: &Path) -> Option<PathBuf> {
+    let mut current = symlink_path.to_path_buf();
+    for _ in 0..MAX_SYMLINK_DEPTH {
+        let meta = match fs::symlink_metadata(&current) {
+            Ok(m) => m,
+            Err(_) => return None,
+        };
+        if !meta.file_type().is_symlink() {
+            let canonical = current.canonicalize().ok()?;
+            if canonical.starts_with(repo_root) {
+                return Some(canonical);
+            } else {
+                tracing::debug!(
+                    "symlink {} -> {} escapes repo {} — ignoring",
+                    symlink_path.display(),
+                    canonical.display(),
+                    repo_root.display()
+                );
+                return None;
+            }
+        }
+        let target = fs::read_link(&current).ok()?;
+        current = if target.is_absolute() {
+            target
+        } else {
+            current.parent()?.join(target)
+        };
+    }
+    tracing::warn!(
+        "symlink chain exceeds depth {} at {}",
+        MAX_SYMLINK_DEPTH,
+        symlink_path.display()
+    );
+    None
+}
+
+/// Scan a manifest file for relative-path tokens and resolve each against
+/// the manifest's dir. Returns the canonical targets that exist on disk
+/// and live inside `repo_root`. Warns on tokens that fail to resolve.
+fn resolve_manifest_refs(manifest_path: &Path, repo_root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let contents = match fs::read_to_string(manifest_path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                "failed to read manifest {}: {}",
+                manifest_path.display(),
+                e
+            );
+            return out;
+        }
+    };
+
+    let parent = match manifest_path.parent() {
+        Some(p) => p,
+        None => return out,
+    };
+
+    for token in manifest::extract_relative_paths(&contents) {
+        let joined = parent.join(&token);
+        match joined.canonicalize() {
+            Ok(canonical) => {
+                if canonical.starts_with(repo_root) {
+                    out.push(canonical);
+                }
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "manifest {} references {} which does not resolve — skipping",
+                    manifest_path.display(),
+                    joined.display()
+                );
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::symlink;
+    use tempfile::TempDir;
+
+    fn mkfile(root: &Path, rel: &str, contents: &str) {
+        let p = root.join(rel);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(p, contents).unwrap();
+    }
+
+    fn mkdir(root: &Path, rel: &str) {
+        fs::create_dir_all(root.join(rel)).unwrap();
+    }
+
+    #[test]
+    fn closure_is_just_fn_dir_when_isolated() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkfile(root, "functions/foo/handler.py", "def handler(e, c): pass\n");
+        let c = compute_closure(&root.join("functions/foo"), root);
+        assert_eq!(c.roots.len(), 1);
+        assert!(c.files.is_empty());
+    }
+
+    #[test]
+    fn closure_follows_pyproject_path_dep() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkfile(root, "functions/foo/handler.py", "");
+        mkfile(
+            root,
+            "functions/foo/pyproject.toml",
+            r#"shared = {path = "../../shared"}"#,
+        );
+        mkfile(root, "shared/core.py", "x = 1");
+        let c = compute_closure(&root.join("functions/foo"), root);
+        let shared = root.join("shared").canonicalize().unwrap();
+        assert!(c.roots.contains(&shared));
+    }
+
+    #[test]
+    fn closure_transitive_across_path_deps() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkfile(root, "functions/foo/handler.py", "");
+        mkfile(
+            root,
+            "functions/foo/pyproject.toml",
+            r#"a = {path = "../../shared-a"}"#,
+        );
+        mkfile(
+            root,
+            "shared-a/pyproject.toml",
+            r#"b = {path = "../shared-b"}"#,
+        );
+        mkfile(root, "shared-a/src/a.py", "");
+        mkfile(root, "shared-b/src/b.py", "");
+        let c = compute_closure(&root.join("functions/foo"), root);
+        assert!(c.roots.contains(&root.join("shared-a").canonicalize().unwrap()));
+        assert!(c.roots.contains(&root.join("shared-b").canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn closure_handles_cycles() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkfile(root, "functions/foo/handler.py", "");
+        mkfile(
+            root,
+            "functions/foo/pyproject.toml",
+            r#"a = {path = "../../shared-a"}"#,
+        );
+        mkfile(
+            root,
+            "shared-a/pyproject.toml",
+            r#"b = {path = "../shared-b"}"#,
+        );
+        mkfile(
+            root,
+            "shared-b/pyproject.toml",
+            r#"a = {path = "../shared-a"}"#,
+        );
+        let c = compute_closure(&root.join("functions/foo"), root);
+        assert!(c.roots.contains(&root.join("shared-a").canonicalize().unwrap()));
+        assert!(c.roots.contains(&root.join("shared-b").canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn closure_follows_symlink_to_dir() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkdir(root, "functions/foo");
+        mkdir(root, "shared");
+        mkfile(root, "shared/util.py", "x = 1");
+        symlink(root.join("shared"), root.join("functions/foo/shared")).unwrap();
+        let c = compute_closure(&root.join("functions/foo"), root);
+        assert!(c.roots.contains(&root.join("shared").canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn closure_follows_deep_nested_symlink() {
+        // Mimics the techno-core pattern: each function has a handler
+        // subdir which contains a symlink to ../../../shared_lib.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkfile(root, "shared_lib/utils/a.rb", "");
+        mkdir(root, "functions/foo/handler");
+        symlink(
+            root.join("shared_lib"),
+            root.join("functions/foo/handler/shared_lib"),
+        )
+        .unwrap();
+        let c = compute_closure(&root.join("functions/foo"), root);
+        assert!(c.roots.contains(&root.join("shared_lib").canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn closure_ignores_symlink_escaping_repo() {
+        let outer = TempDir::new().unwrap();
+        let repo = TempDir::new().unwrap();
+        let root = repo.path();
+        mkdir(root, "functions/foo");
+        mkdir(outer.path(), "external");
+        fs::write(outer.path().join("external/x.txt"), "x").unwrap();
+        symlink(
+            outer.path().join("external"),
+            root.join("functions/foo/external"),
+        )
+        .unwrap();
+        let c = compute_closure(&root.join("functions/foo"), root);
+        let outer_canonical = outer.path().join("external").canonicalize().unwrap();
+        assert!(!c.roots.contains(&outer_canonical));
+    }
+
+    #[test]
+    fn closure_empty_for_nonexistent_fn_dir() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let c = compute_closure(&root.join("/tmp/tc/synthetic"), root);
+        assert!(c.roots.is_empty() && c.files.is_empty());
+    }
+
+    #[test]
+    fn closure_warns_on_missing_path_dep() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkfile(root, "functions/foo/handler.py", "");
+        mkfile(
+            root,
+            "functions/foo/pyproject.toml",
+            r#"missing = {path = "../../does-not-exist"}"#,
+        );
+        let c = compute_closure(&root.join("functions/foo"), root);
+        let missing = root.join("does-not-exist");
+        assert!(!c.roots.contains(&missing));
+    }
+
+    #[test]
+    fn contains_works_for_file_under_root() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkfile(root, "functions/foo/handler.py", "");
+        let c = compute_closure(&root.join("functions/foo"), root);
+        let abs = root.canonicalize().unwrap().join("functions/foo/handler.py");
+        assert!(c.contains(&abs));
+        assert!(!c.contains(&root.canonicalize().unwrap().join("other/bar.py")));
+    }
+
+    #[test]
+    fn contains_works_for_symlinked_file_target() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkdir(root, "functions/foo");
+        mkfile(root, "shared/util.py", "");
+        symlink(
+            root.join("shared/util.py"),
+            root.join("functions/foo/util.py"),
+        )
+        .unwrap();
+        let c = compute_closure(&root.join("functions/foo"), root);
+        let abs = root.canonicalize().unwrap().join("shared/util.py");
+        assert!(c.contains(&abs));
+    }
+
+    #[test]
+    fn analyzer_caches_shared_dir_across_functions() {
+        // Two functions symlinking to the same shared dir should walk the
+        // shared dir exactly once.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkfile(root, "shared_lib/a.rb", "");
+        mkfile(root, "shared_lib/b.rb", "");
+        mkdir(root, "functions/foo");
+        mkdir(root, "functions/bar");
+        symlink(
+            root.join("shared_lib"),
+            root.join("functions/foo/shared_lib"),
+        )
+        .unwrap();
+        symlink(
+            root.join("shared_lib"),
+            root.join("functions/bar/shared_lib"),
+        )
+        .unwrap();
+
+        let analyzer = Analyzer::new(root).unwrap();
+        let foo = analyzer.closure(&root.join("functions/foo"));
+        let bar = analyzer.closure(&root.join("functions/bar"));
+
+        let shared = root.join("shared_lib").canonicalize().unwrap();
+        assert!(foo.roots.contains(&shared));
+        assert!(bar.roots.contains(&shared));
+
+        // Three unique dirs were reffed (foo, bar, shared_lib) — the
+        // analyzer's cache should show exactly those entries.
+        let refs = analyzer.refs.borrow();
+        assert_eq!(refs.len(), 3, "cache contents: {:?}", refs.keys());
+    }
+}

--- a/lib/differ/src/lib.rs
+++ b/lib/differ/src/lib.rs
@@ -1,166 +1,323 @@
-use composer::{
-    Function,
-    Topology,
-};
-use kit as u;
-use kit::*;
-use std::collections::HashMap;
+//! Function-level change detection for `tc` topologies.
+//!
+//! High-level: between git tags A (older) and B (newer), determine the
+//! subset of functions in a topology whose **code** artifact inputs have
+//! changed, and therefore must be redeployed.
+//!
+//! Design invariants that matter for perf:
+//!   - The git diff runs ONCE per `diff_fns` invocation, regardless of
+//!     function count.
+//!   - The repo root is canonicalized ONCE; all downstream comparisons use
+//!     the canonical path.
+//!   - Directories are walked ONCE per unique path across all functions
+//!     (via [`deps::Analyzer`]). Shared libraries referenced by N functions
+//!     are analyzed a single time.
+//!   - Matching is pure `starts_with` on canonical paths — no per-call
+//!     canonicalization.
 
-fn files_modified_in_branch() -> Vec<String> {
+mod deps;
+mod manifest;
+
+pub use deps::{compute_closure, Analyzer, Closure};
+
+use composer::{Function, Topology};
+use kit as u;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Canonicalized absolute paths of files changed between two refs. We
+/// store these pre-canonicalized so per-function matching is just a cheap
+/// `starts_with` scan.
+#[derive(Debug, Default, Clone)]
+struct DiffSet {
+    files: Vec<PathBuf>,
+}
+
+impl DiffSet {
+    fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    /// True iff any file in the diff lies under `dir` (exact `starts_with`).
+    fn any_under(&self, dir: &Path) -> bool {
+        self.files.iter().any(|f| f.starts_with(dir))
+    }
+
+    /// True iff any file in the diff is covered by the closure — either
+    /// under one of its roots or exactly equal to one of its extra files.
+    fn intersects(&self, closure: &Closure) -> bool {
+        for f in &self.files {
+            if closure.contains(f) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+fn repo_root_canonical() -> PathBuf {
+    PathBuf::from(u::root())
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from(u::root()))
+}
+
+/// Return the list of changed files (repo-relative paths) between
+/// `from_tag` and `to_tag` within `namespace`.
+pub fn find_between_versions(namespace: &str, from: &str, to: &str) -> Vec<String> {
+    if from == to {
+        return vec![];
+    }
     let dir = u::pwd();
-    let cmd = "git rev-parse --abbrev-ref HEAD";
-    let branch = sh(&cmd, &dir);
-    if branch == "main" || branch == "HEAD" {
-        vec![]
-    } else {
-        let out = u::sh(
+    let from_tag = format!("{}-{}", namespace, from);
+    let to_tag = format!("{}-{}", namespace, to);
+
+    // Only fetch tags that aren't already resolvable locally. Saves
+    // multi-second network round-trips on repeat invocations / CI runs
+    // that pre-fetched tags.
+    if u::sh(
+        &format!("git rev-parse --verify --quiet refs/tags/{}", &to_tag),
+        &dir,
+    )
+    .is_empty()
+    {
+        u::sh(
             &format!(
-                "git whatchanged --name-only --pretty=\"\" main..{} | xargs dirname | uniq",
-                branch
+                "git fetch origin +refs/tags/{tag}:refs/tags/{tag} 2>/dev/null || true",
+                tag = &to_tag
             ),
             &dir,
         );
-        tracing::debug!("{}", &out);
-        u::split_lines(&out).iter().map(|v| v.to_string()).collect()
     }
+    if u::sh(
+        &format!("git rev-parse --verify --quiet refs/tags/{}", &from_tag),
+        &dir,
+    )
+    .is_empty()
+    {
+        u::sh(
+            &format!(
+                "git fetch origin +refs/tags/{tag}:refs/tags/{tag} 2>/dev/null || true",
+                tag = &from_tag
+            ),
+            &dir,
+        );
+    }
+
+    let cmd = format!("git diff --name-only {}..{}", &from_tag, &to_tag);
+    tracing::debug!("{}", &cmd);
+    let out = u::sh(&cmd, &dir);
+    u::split_lines(&out)
+        .iter()
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn files_modified_in_branch() -> Vec<String> {
+    let dir = u::pwd();
+    let branch = u::sh("git rev-parse --abbrev-ref HEAD", &dir);
+    if branch == "HEAD" {
+        return vec![];
+    }
+    let default = {
+        let raw = u::sh(
+            "git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'",
+            &dir,
+        );
+        if raw.is_empty() {
+            "main".to_string()
+        } else {
+            raw
+        }
+    };
+    if branch == default {
+        return vec![];
+    }
+    let out = u::sh(
+        &format!("git diff --name-only {}...{}", &default, &branch),
+        &dir,
+    );
+    u::split_lines(&out)
+        .iter()
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
 }
 
 fn files_modified_uncommitted() -> Vec<String> {
     let dir = u::pwd();
-    let out = u::sh("git ls-files -m | xargs dirname | sort | uniq", &dir);
-    u::split_lines(&out).iter().map(|v| v.to_string()).collect()
+    let out = u::sh("git ls-files -m", &dir);
+    u::split_lines(&out)
+        .iter()
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
 }
 
-pub fn find_between_versions(namespace: &str, from: &str, to: &str) -> Vec<String> {
-    let dir = pwd();
-    let from_tag = format!("{}-{}", namespace, from);
-    let to_tag = format!("{}-{}", namespace, to);
-    sh(
-        &format!(
-            "git fetch origin +refs/tags/{}:refs/tags/{}",
-            &to_tag, &to_tag
-        ),
-        &dir,
-    );
-    sh(
-        &format!(
-            "git fetch origin +refs/tags/{}:refs/tags/{}",
-            &from_tag, &from_tag
-        ),
-        &dir,
-    );
-
-    let cmd = format!(
-        r#"git diff {}...{} --name-only {} | xargs dirname | sort | uniq"#,
-        &from_tag, &to_tag, &u::root()
-    );
-    tracing::debug!("{}", &cmd);
-    let out = sh(&cmd, &dir);
-    let lines = kit::split_lines(&out);
-    lines.iter().map(|s| s.to_string()).collect()
-}
-
-fn has_changed(paths: &Vec<String>, dir: &str) -> bool {
-    let adir = u::absolutize(&u::pwd(), dir);
-    for p in paths {
-        let maybe_rdir = adir.strip_prefix(&format!("{}/", &u::root()));
-
-        if let Some(rdir) = maybe_rdir {
-             if p.starts_with(rdir) {
-                tracing::debug!("Found {} {}", &p, &rdir);
-                return true
-            }
-        }
-    }
-    return false
-}
-
-pub fn has_shared_lib(paths: &Vec<String>) -> bool {
-    for path in paths {
-        let dir = u::pwd();
-        let ext = u::absolutize(&dir, "../shared");
-        let local = u::absolutize(&dir, "./shared");
-        let ap = u::absolutize(&dir, &path);
-
-        if ap.starts_with(&ext) || ap.starts_with(&local) {
-            println!("{} {} {}", &ap, &ext, &local);
-            return true
-        }
-    }
-    false
-}
-
-pub fn diff_fns(
+/// Build a canonicalized diff set. Paths that don't resolve on disk are
+/// kept as logical joins (they still match starts_with for the deleted-
+/// file case).
+fn build_diff_set(
     namespace: &str,
     from: &str,
     to: &str,
-    fns: &HashMap<String, Function>,
-) -> HashMap<String, Function> {
-    let mut changed_fns: HashMap<String, Function> = HashMap::new();
-
-    tracing::debug!("Diffing namespace {} from: {} to: {}", namespace, from, to);
-
-    let paths = if to == from {
-        vec![]
-    } else {
-        find_between_versions(namespace, from, to)
-    };
-
-    let fmod_1 = match std::env::var("CI") {
-        Ok(_) => vec![],
-        Err(_) => files_modified_uncommitted(),
-    };
-    let fmod_2 = files_modified_in_branch();
-
-
-    for (name, f) in fns {
-        if has_changed(&paths, &f.dir) {
-            changed_fns.insert(name.to_string(), f.clone());
-        }
-
-        let maybe_pdir = &f.dir.strip_prefix(&format!("{}/", u::pwd()));
-        if let Some(pdir) = maybe_pdir {
-            if fmod_1.contains(&pdir.to_string()) {
-                changed_fns.insert(name.to_string(), f.clone());
-            }
-        }
-
-        let maybe_rdir = &f.dir.strip_prefix(&format!("{}/", &u::root()));
-        if let Some(rdir) = maybe_rdir {
-            if fmod_2.contains(&rdir.to_string()) {
-                changed_fns.insert(name.to_string(), f.clone());
-            }
-        }
+    repo_root: &Path,
+) -> DiffSet {
+    let mut rels: Vec<String> = find_between_versions(namespace, from, to);
+    if std::env::var("CI").is_err() {
+        rels.extend(files_modified_uncommitted());
+        rels.extend(files_modified_in_branch());
     }
+    rels.sort();
+    rels.dedup();
 
-    if has_shared_lib(&paths) && changed_fns.is_empty() {
-        fns.clone()
-    } else {
-        changed_fns
-    }
-
-
+    let files: Vec<PathBuf> = rels
+        .into_iter()
+        .map(|r| {
+            let joined = repo_root.join(&r);
+            // Canonicalize when possible (handles deleted files by falling
+            // back to the logical join — which still prefix-matches any
+            // closure that included that path).
+            joined.canonicalize().unwrap_or(joined)
+        })
+        .collect();
+    DiffSet { files }
 }
 
-pub fn diff(topology: &Topology, from: &str, to: &str) {
-    let fns = diff_fns(&topology.namespace, &from, &to, &topology.functions);
-
-    println!("Modified functions:");
-    for (name, _) in fns {
-        println!("  - {}", name);
+/// Collect every `(owning-topology-dir, function-name, Function)` tuple
+/// reachable from `topology`, recursively descending into nested nodes.
+/// The topology dir is kept alongside each function so the transducer
+/// policy can still apply per-topology.
+fn collect_functions<'a>(
+    topology: &'a Topology,
+    out: &mut Vec<(&'a Topology, &'a String, &'a Function)>,
+) {
+    for (name, f) in &topology.functions {
+        out.push((topology, name, f));
     }
     for (_, node) in &topology.nodes {
-        let fns = diff_fns(&topology.namespace, &from, &to, &node.functions);
-        for (name, _) in fns {
-            println!(" - {}/{}", node.namespace, name);
+        collect_functions(node, out);
+    }
+}
+
+/// Collect every subtopology (self + nested), so transducer policy can
+/// apply to each owning topology independently.
+fn collect_topologies<'a>(topology: &'a Topology, out: &mut Vec<&'a Topology>) {
+    out.push(topology);
+    for (_, node) in &topology.nodes {
+        collect_topologies(node, out);
+    }
+}
+
+/// Filter the (recursively-collected) functions of `topology` down to
+/// those whose code-dep closure intersects the git diff between `from`
+/// and `to`.
+///
+/// First-deploy semantics: if `from` is empty, all functions (including
+/// transducers) are returned.
+pub fn diff_fns(
+    topology: &Topology,
+    from: &str,
+    to: &str,
+) -> HashMap<String, Function> {
+    let all_topologies = {
+        let mut v = Vec::new();
+        collect_topologies(topology, &mut v);
+        v
+    };
+    let all_functions = {
+        let mut v = Vec::new();
+        collect_functions(topology, &mut v);
+        v
+    };
+    tracing::debug!(
+        "differ scanning {} topology(ies), {} function(s)",
+        all_topologies.len(),
+        all_functions.len()
+    );
+
+    let first_deploy = from.is_empty();
+    if first_deploy {
+        tracing::debug!(
+            "no prior version for {} — marking {} functions + transducers changed",
+            &topology.namespace,
+            all_functions.len()
+        );
+        let mut out: HashMap<String, Function> = all_functions
+            .iter()
+            .map(|(_, name, f)| ((*name).clone(), (*f).clone()))
+            .collect();
+        for t in &all_topologies {
+            if let Some(tx) = &t.transducer {
+                out.insert(tx.name.clone(), tx.function.clone());
+            }
+        }
+        return out;
+    }
+
+    if from == to {
+        return HashMap::new();
+    }
+
+    let repo_root = repo_root_canonical();
+    let diff = build_diff_set(&topology.namespace, from, to, &repo_root);
+    if diff.is_empty() {
+        tracing::debug!("empty diff for {} {}..{}", &topology.namespace, from, to);
+        return HashMap::new();
+    }
+
+    let analyzer = match Analyzer::new(&repo_root) {
+        Some(a) => a,
+        None => {
+            tracing::warn!(
+                "could not canonicalize repo root {}; skipping diff",
+                repo_root.display()
+            );
+            return HashMap::new();
+        }
+    };
+
+    let mut changed: HashMap<String, Function> = HashMap::new();
+    for (_owning, name, f) in &all_functions {
+        let closure = analyzer.closure(&PathBuf::from(&f.dir));
+        if diff.intersects(&closure) {
+            changed.insert((*name).clone(), (*f).clone());
         }
     }
 
-    println!("");
-    println!("Changelog:");
+    // Transducer Policy B: per owning topology, include the transducer if
+    // any diff path is under the topology's own dir.
+    for t in &all_topologies {
+        if let Some(tx) = &t.transducer {
+            let topo_dir = match PathBuf::from(&t.dir).canonicalize() {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            if diff.any_under(&topo_dir) {
+                changed.insert(tx.name.clone(), tx.function.clone());
+            }
+        }
+    }
 
-    let f = format!("{}-{}", &topology.namespace, &from);
-    let t = format!("{}-{}", &topology.namespace, &to);
+    changed
+}
+
+/// CLI helper: print the functions that changed between two tags, plus a
+/// changelog from the `tagger` crate.
+pub fn diff(topology: &Topology, from: &str, to: &str) {
+    let fns = diff_fns(topology, from, to);
+
+    println!("Modified functions:");
+    let mut names: Vec<&String> = fns.keys().collect();
+    names.sort();
+    for name in names {
+        println!("  - {}", name);
+    }
+
+    println!();
+    println!("Changelog:");
+    let f = format!("{}-{}", &topology.namespace, from);
+    let t = format!("{}-{}", &topology.namespace, to);
     let changes = tagger::commits(&f, &t);
     println!("{}", changes);
 }

--- a/lib/differ/src/lib.rs
+++ b/lib/differ/src/lib.rs
@@ -196,10 +196,21 @@ fn build_diff_set(
 /// functions and would cause those functions to be re-resolved with the
 /// wrong context by `resolver::resolve`.
 ///
+/// `namespace` is the **root** topology's namespace — it determines the
+/// git tag prefix used when constructing the diff range (`{namespace}-
+/// {from}..{namespace}-{to}`). It is passed explicitly rather than read
+/// from `topology.namespace` because `topology` may be a nested node
+/// whose own namespace differs from the root's, and tags in this repo
+/// are keyed by the root namespace only. Using `topology.namespace`
+/// here would silently produce an empty diff for nested nodes (lookup
+/// of nonexistent tags), causing functions to be skipped from
+/// re-deployment.
+///
 /// First-deploy semantics: if `from` is empty, all of this topology's
 /// own functions (plus its transducer, if any) are returned.
 pub fn diff_fns(
     topology: &Topology,
+    namespace: &str,
     from: &str,
     to: &str,
 ) -> HashMap<String, Function> {
@@ -207,7 +218,7 @@ pub fn diff_fns(
     if first_deploy {
         tracing::debug!(
             "no prior version for {} — marking {} function(s) + transducer changed",
-            &topology.namespace,
+            namespace,
             topology.functions.len()
         );
         let mut out: HashMap<String, Function> = topology.functions.clone();
@@ -222,9 +233,9 @@ pub fn diff_fns(
     }
 
     let repo_root = repo_root_canonical();
-    let diff = build_diff_set(&topology.namespace, from, to, &repo_root);
+    let diff = build_diff_set(namespace, from, to, &repo_root);
     if diff.is_empty() {
-        tracing::debug!("empty diff for {} {}..{}", &topology.namespace, from, to);
+        tracing::debug!("empty diff for {} {}..{}", namespace, from, to);
         return HashMap::new();
     }
 

--- a/lib/differ/src/lib.rs
+++ b/lib/differ/src/lib.rs
@@ -184,73 +184,35 @@ fn build_diff_set(
     DiffSet { files }
 }
 
-/// Collect every `(owning-topology-dir, function-name, Function)` tuple
-/// reachable from `topology`, recursively descending into nested nodes.
-/// The topology dir is kept alongside each function so the transducer
-/// policy can still apply per-topology.
-fn collect_functions<'a>(
-    topology: &'a Topology,
-    out: &mut Vec<(&'a Topology, &'a String, &'a Function)>,
-) {
-    for (name, f) in &topology.functions {
-        out.push((topology, name, f));
-    }
-    for (_, node) in &topology.nodes {
-        collect_functions(node, out);
-    }
-}
-
-/// Collect every subtopology (self + nested), so transducer policy can
-/// apply to each owning topology independently.
-fn collect_topologies<'a>(topology: &'a Topology, out: &mut Vec<&'a Topology>) {
-    out.push(topology);
-    for (_, node) in &topology.nodes {
-        collect_topologies(node, out);
-    }
-}
-
-/// Filter the (recursively-collected) functions of `topology` down to
-/// those whose code-dep closure intersects the git diff between `from`
-/// and `to`.
+/// Filter `topology`'s own `functions` down to those whose code-dep
+/// closure intersects the git diff between `from` and `to`.
 ///
-/// First-deploy semantics: if `from` is empty, all functions (including
-/// transducers) are returned.
+/// Shallow by design: this processes `topology.functions` and the
+/// transducer of `topology` itself — **not** nested `topology.nodes`.
+/// Callers that need to process nested topologies should iterate them
+/// and call `diff_fns` for each, matching the resolver's per-topology
+/// iteration pattern. A recursive variant would cause the root
+/// topology's `functions` map to be contaminated with node-level
+/// functions and would cause those functions to be re-resolved with the
+/// wrong context by `resolver::resolve`.
+///
+/// First-deploy semantics: if `from` is empty, all of this topology's
+/// own functions (plus its transducer, if any) are returned.
 pub fn diff_fns(
     topology: &Topology,
     from: &str,
     to: &str,
 ) -> HashMap<String, Function> {
-    let all_topologies = {
-        let mut v = Vec::new();
-        collect_topologies(topology, &mut v);
-        v
-    };
-    let all_functions = {
-        let mut v = Vec::new();
-        collect_functions(topology, &mut v);
-        v
-    };
-    tracing::debug!(
-        "differ scanning {} topology(ies), {} function(s)",
-        all_topologies.len(),
-        all_functions.len()
-    );
-
     let first_deploy = from.is_empty();
     if first_deploy {
         tracing::debug!(
-            "no prior version for {} — marking {} functions + transducers changed",
+            "no prior version for {} — marking {} function(s) + transducer changed",
             &topology.namespace,
-            all_functions.len()
+            topology.functions.len()
         );
-        let mut out: HashMap<String, Function> = all_functions
-            .iter()
-            .map(|(_, name, f)| ((*name).clone(), (*f).clone()))
-            .collect();
-        for t in &all_topologies {
-            if let Some(tx) = &t.transducer {
-                out.insert(tx.name.clone(), tx.function.clone());
-            }
+        let mut out: HashMap<String, Function> = topology.functions.clone();
+        if let Some(tx) = &topology.transducer {
+            out.insert(tx.name.clone(), tx.function.clone());
         }
         return out;
     }
@@ -277,39 +239,78 @@ pub fn diff_fns(
         }
     };
 
+    diff_fns_with(topology, &diff, &analyzer)
+}
+
+/// Internal helper: filter one topology's own functions against a
+/// pre-built diff set + analyzer. Used by both the public `diff_fns` and
+/// the CLI `diff` walker so the git diff + Analyzer cache are built once
+/// per invocation.
+fn diff_fns_with(
+    topology: &Topology,
+    diff: &DiffSet,
+    analyzer: &Analyzer,
+) -> HashMap<String, Function> {
     let mut changed: HashMap<String, Function> = HashMap::new();
-    for (_owning, name, f) in &all_functions {
+    for (name, f) in &topology.functions {
         let closure = analyzer.closure(&PathBuf::from(&f.dir));
         if diff.intersects(&closure) {
-            changed.insert((*name).clone(), (*f).clone());
+            changed.insert(name.clone(), f.clone());
         }
     }
-
-    // Transducer Policy B: per owning topology, include the transducer if
-    // any diff path is under the topology's own dir.
-    for t in &all_topologies {
-        if let Some(tx) = &t.transducer {
-            let topo_dir = match PathBuf::from(&t.dir).canonicalize() {
-                Ok(p) => p,
-                Err(_) => continue,
-            };
+    // Transducer Policy B: include the topology's transducer if any
+    // diff path is under the topology's own dir.
+    if let Some(tx) = &topology.transducer {
+        if let Ok(topo_dir) = PathBuf::from(&topology.dir).canonicalize() {
             if diff.any_under(&topo_dir) {
                 changed.insert(tx.name.clone(), tx.function.clone());
             }
         }
     }
-
     changed
 }
 
-/// CLI helper: print the functions that changed between two tags, plus a
-/// changelog from the `tagger` crate.
+/// Walk `topology` and every nested node, pushing each onto `out`.
+fn collect_topologies<'a>(topology: &'a Topology, out: &mut Vec<&'a Topology>) {
+    out.push(topology);
+    for node in topology.nodes.values() {
+        collect_topologies(node, out);
+    }
+}
+
+/// CLI helper: print the functions that changed between two tags across
+/// the root topology and all nested nodes, plus a changelog from the
+/// `tagger` crate. Computes the git diff and Analyzer cache once and
+/// reuses them across all topologies.
 pub fn diff(topology: &Topology, from: &str, to: &str) {
-    let fns = diff_fns(topology, from, to);
+    let first_deploy = from.is_empty();
+    let mut topologies: Vec<&Topology> = Vec::new();
+    collect_topologies(topology, &mut topologies);
+
+    let mut names: Vec<String> = Vec::new();
+
+    if first_deploy {
+        for t in &topologies {
+            names.extend(t.functions.keys().cloned());
+            if let Some(tx) = &t.transducer {
+                names.push(tx.name.clone());
+            }
+        }
+    } else if from != to {
+        let repo_root = repo_root_canonical();
+        let diff = build_diff_set(&topology.namespace, from, to, &repo_root);
+        if !diff.is_empty() {
+            if let Some(analyzer) = Analyzer::new(&repo_root) {
+                for t in &topologies {
+                    names.extend(diff_fns_with(t, &diff, &analyzer).into_keys());
+                }
+            }
+        }
+    }
 
     println!("Modified functions:");
-    let mut names: Vec<&String> = fns.keys().collect();
     names.sort();
+    names.dedup();
     for name in names {
         println!("  - {}", name);
     }

--- a/lib/differ/src/manifest.rs
+++ b/lib/differ/src/manifest.rs
@@ -1,0 +1,192 @@
+//! Manifest file detection and relative-path extraction.
+//!
+//! We recognize a fixed set of dependency-declaration files (manifests +
+//! lockfiles) and scan them for tokens that look like relative filesystem paths
+//! (starting with `./` or `../`). We deliberately do not parse these files
+//! structurally — a ripgrep-style extraction handles every format uniformly
+//! and is robust against format evolution.
+//!
+//! Limitations (documented):
+//! - We do NOT scan arbitrary source code. Relative paths embedded in e.g.
+//!   Python source (`open('../data.csv')`) are not detected.
+//! - We do NOT interpret shell commands in `build.pre` / `build.post` / etc.
+//! - We do NOT follow named-reference dependencies (layer names, etc.).
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// Filenames recognized as dependency-declaration files.
+const MANIFEST_NAMES: &[&str] = &[
+    // Python
+    "pyproject.toml",
+    "Pipfile",
+    "Pipfile.lock",
+    "poetry.lock",
+    "uv.lock",
+    "setup.cfg",
+    // Ruby
+    "Gemfile",
+    "Gemfile.lock",
+    // Node
+    "package.json",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    // Rust
+    "Cargo.toml",
+    "Cargo.lock",
+];
+
+/// Returns true if `file_name` (basename only) is a recognized manifest.
+pub fn is_manifest(file_name: &str) -> bool {
+    if MANIFEST_NAMES.contains(&file_name) {
+        return true;
+    }
+    // requirements*.txt family
+    if file_name.starts_with("requirements") && file_name.ends_with(".txt") {
+        return true;
+    }
+    false
+}
+
+fn rel_path_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    // Match tokens that:
+    //   - are preceded by start-of-line, whitespace, or a delimiter common in
+    //     config/lock formats (quotes, =, :, comma, paren, bracket)
+    //   - start with `./` or `../`
+    //   - continue with path-safe characters (alnum, `.`, `/`, `_`, `-`)
+    //
+    // We capture the path token in group 1. The leading context character is
+    // intentionally non-capturing so we don't swallow it.
+    RE.get_or_init(|| {
+        Regex::new(r#"(?:^|[\s"'=:,(\[])(\.{1,2}/[A-Za-z0-9_./\-]+)"#).unwrap()
+    })
+}
+
+/// Extract every distinct relative-path token from `contents`.
+///
+/// Output is ordered and deduplicated.
+pub fn extract_relative_paths(contents: &str) -> Vec<String> {
+    let mut seen = std::collections::BTreeSet::new();
+    let mut out = Vec::new();
+    for cap in rel_path_regex().captures_iter(contents) {
+        if let Some(m) = cap.get(1) {
+            let s = m.as_str().trim_end_matches(|c: char| c == '.' || c == '/');
+            // Filter out trivial noise: bare `.` or `..` or `./` tokens after trim
+            if s.is_empty() || s == "." || s == ".." {
+                continue;
+            }
+            if seen.insert(s.to_string()) {
+                out.push(s.to_string());
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_recognition() {
+        assert!(is_manifest("pyproject.toml"));
+        assert!(is_manifest("Cargo.toml"));
+        assert!(is_manifest("Cargo.lock"));
+        assert!(is_manifest("package.json"));
+        assert!(is_manifest("Gemfile"));
+        assert!(is_manifest("requirements.txt"));
+        assert!(is_manifest("requirements-dev.txt"));
+        assert!(is_manifest("requirements_prod.txt"));
+        assert!(!is_manifest("handler.py"));
+        assert!(!is_manifest("README.md"));
+        assert!(!is_manifest("requirements.md"));
+    }
+
+    #[test]
+    fn extract_pyproject_path_dep() {
+        let s = r#"[tool.poetry.dependencies]
+python = "^3.10"
+shared = {path = "../shared", develop = true}
+core = {path = "../../core"}
+"#;
+        let paths = extract_relative_paths(s);
+        assert!(paths.contains(&"../shared".to_string()));
+        assert!(paths.contains(&"../../core".to_string()));
+    }
+
+    #[test]
+    fn extract_cargo_path_dep() {
+        let s = r#"
+[dependencies]
+kit = { path = "../kit" }
+foo = { version = "1.0", path = "./local" }
+bar = "1.0"
+"#;
+        let paths = extract_relative_paths(s);
+        assert!(paths.contains(&"../kit".to_string()));
+        assert!(paths.contains(&"./local".to_string()));
+    }
+
+    #[test]
+    fn extract_package_json_file_dep() {
+        let s = r#"{
+  "dependencies": {
+    "common": "file:../common",
+    "core": "link:../../core",
+    "ext": "^1.0.0"
+  }
+}"#;
+        let paths = extract_relative_paths(s);
+        assert!(paths.contains(&"../common".to_string()));
+        assert!(paths.contains(&"../../core".to_string()));
+    }
+
+    #[test]
+    fn extract_requirements_txt() {
+        let s = "-r ../shared/requirements.txt\n-e ../pkg\nrequests==2.0\n";
+        let paths = extract_relative_paths(s);
+        assert!(paths.contains(&"../shared/requirements.txt".to_string()));
+        assert!(paths.contains(&"../pkg".to_string()));
+    }
+
+    #[test]
+    fn extract_gemfile() {
+        let s = r#"source "https://rubygems.org"
+gem "foo", path: "../foo"
+gem "bar", path: '../../bar'
+"#;
+        let paths = extract_relative_paths(s);
+        assert!(paths.contains(&"../foo".to_string()));
+        assert!(paths.contains(&"../../bar".to_string()));
+    }
+
+    #[test]
+    fn no_false_positive_on_semver() {
+        let s = r#"foo = "1.0.0""#;
+        let paths = extract_relative_paths(s);
+        assert!(paths.is_empty(), "got: {:?}", paths);
+    }
+
+    #[test]
+    fn no_false_positive_on_url() {
+        let s = r#"repository = "https://example.com/a/../b""#;
+        let paths = extract_relative_paths(s);
+        // The "b" under "a/.." is embedded inside a URL without preceding
+        // whitespace/delimiter immediately before the "..", so the regex may
+        // or may not match depending on URL shape. We don't promise precision
+        // for URL-embedded tokens — downstream existence check filters them.
+        // Just make sure this doesn't panic.
+        let _ = paths;
+    }
+
+    #[test]
+    fn dedup() {
+        let s = r#"a = "../foo"
+b = "../foo"
+c = "../bar""#;
+        let paths = extract_relative_paths(s);
+        assert_eq!(paths.len(), 2);
+    }
+}

--- a/lib/differ/src/manifest.rs
+++ b/lib/differ/src/manifest.rs
@@ -24,6 +24,7 @@ const MANIFEST_NAMES: &[&str] = &[
     "poetry.lock",
     "uv.lock",
     "setup.cfg",
+    "requirements.in",
     // Ruby
     "Gemfile",
     "Gemfile.lock",
@@ -35,6 +36,14 @@ const MANIFEST_NAMES: &[&str] = &[
     // Rust
     "Cargo.toml",
     "Cargo.lock",
+    // JVM (Java / Kotlin / Clojure)
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "settings.gradle",
+    "settings.gradle.kts",
+    "project.clj",
+    "deps.edn",
 ];
 
 /// Returns true if `file_name` (basename only) is a recognized manifest.
@@ -60,7 +69,7 @@ fn rel_path_regex() -> &'static Regex {
     // We capture the path token in group 1. The leading context character is
     // intentionally non-capturing so we don't swallow it.
     RE.get_or_init(|| {
-        Regex::new(r#"(?:^|[\s"'=:,(\[])(\.{1,2}/[A-Za-z0-9_./\-]+)"#).unwrap()
+        Regex::new(r#"(?:^|[\s"'=:,(\[>])(\.{1,2}/[A-Za-z0-9_./\-]+)"#).unwrap()
     })
 }
 
@@ -99,6 +108,14 @@ mod tests {
         assert!(is_manifest("requirements.txt"));
         assert!(is_manifest("requirements-dev.txt"));
         assert!(is_manifest("requirements_prod.txt"));
+        assert!(is_manifest("requirements.in"));
+        assert!(is_manifest("pom.xml"));
+        assert!(is_manifest("build.gradle"));
+        assert!(is_manifest("build.gradle.kts"));
+        assert!(is_manifest("settings.gradle"));
+        assert!(is_manifest("settings.gradle.kts"));
+        assert!(is_manifest("project.clj"));
+        assert!(is_manifest("deps.edn"));
         assert!(!is_manifest("handler.py"));
         assert!(!is_manifest("README.md"));
         assert!(!is_manifest("requirements.md"));
@@ -179,6 +196,128 @@ gem "bar", path: '../../bar'
         // for URL-embedded tokens — downstream existence check filters them.
         // Just make sure this doesn't panic.
         let _ = paths;
+    }
+
+    #[test]
+    fn extract_pom_xml_relative_paths() {
+        let s = r#"<project>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../parent</relativePath>
+  </parent>
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>shared</artifactId>
+      <version>1.0</version>
+      <scope>system</scope>
+      <systemPath>../libs/shared.jar</systemPath>
+    </dependency>
+  </dependencies>
+</project>
+"#;
+        let paths = extract_relative_paths(s);
+        assert!(paths.contains(&"../parent".to_string()), "got: {:?}", paths);
+        assert!(
+            paths.contains(&"../libs/shared.jar".to_string()),
+            "got: {:?}",
+            paths
+        );
+    }
+
+    #[test]
+    fn extract_build_gradle_paths() {
+        let s = r#"dependencies {
+    implementation files('../shared/lib.jar')
+    implementation files("../../core/build/libs/core.jar")
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
+}
+"#;
+        let paths = extract_relative_paths(s);
+        assert!(
+            paths.contains(&"../shared/lib.jar".to_string()),
+            "got: {:?}",
+            paths
+        );
+        assert!(
+            paths.contains(&"../../core/build/libs/core.jar".to_string()),
+            "got: {:?}",
+            paths
+        );
+    }
+
+    #[test]
+    fn extract_settings_gradle_paths() {
+        let s = r#"rootProject.name = 'my-app'
+include ':shared'
+project(':shared').projectDir = file('../shared')
+"#;
+        let paths = extract_relative_paths(s);
+        assert!(
+            paths.contains(&"../shared".to_string()),
+            "got: {:?}",
+            paths
+        );
+        // ':shared' is a Gradle project reference, not a path — must not appear.
+        assert!(!paths.iter().any(|p| p.contains(":shared")), "got: {:?}", paths);
+    }
+
+    #[test]
+    fn extract_project_clj_paths() {
+        let s = r#"(defproject my-app "0.1.0"
+  :description "Example"
+  :source-paths ["../shared/src" "../../common/src"]
+  :resource-paths ["../resources"]
+  :dependencies [[org.clojure/clojure "1.11.1"]])
+"#;
+        let paths = extract_relative_paths(s);
+        assert!(
+            paths.contains(&"../shared/src".to_string()),
+            "got: {:?}",
+            paths
+        );
+        assert!(
+            paths.contains(&"../../common/src".to_string()),
+            "got: {:?}",
+            paths
+        );
+        assert!(
+            paths.contains(&"../resources".to_string()),
+            "got: {:?}",
+            paths
+        );
+    }
+
+    #[test]
+    fn extract_deps_edn_paths() {
+        let s = r#"{:deps {com.foo/bar {:local/root "../foo"}
+                com.baz/qux {:local/root "../../shared"}}}
+"#;
+        let paths = extract_relative_paths(s);
+        assert!(paths.contains(&"../foo".to_string()), "got: {:?}", paths);
+        assert!(
+            paths.contains(&"../../shared".to_string()),
+            "got: {:?}",
+            paths
+        );
+    }
+
+    #[test]
+    fn extract_requirements_in_paths() {
+        let s = "-r ../shared/requirements.in\n-e ../local-pkg\nrequests\n";
+        let paths = extract_relative_paths(s);
+        assert!(
+            paths.contains(&"../shared/requirements.in".to_string()),
+            "got: {:?}",
+            paths
+        );
+        assert!(
+            paths.contains(&"../local-pkg".to_string()),
+            "got: {:?}",
+            paths
+        );
     }
 
     #[test]

--- a/lib/kit/src/git.rs
+++ b/lib/kit/src/git.rs
@@ -3,6 +3,8 @@ use crate::{
     sh,
 };
 use regex::Regex;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 
 fn extract_version(s: &str) -> String {
     let re: Regex = Regex::new(r"(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.\d+)").unwrap();
@@ -13,15 +15,31 @@ fn extract_version(s: &str) -> String {
     }
 }
 
+/// Returns the most recent tag matching `{prefix}-*` reachable from HEAD,
+/// stripped to a semver string. Results are cached for the lifetime of the
+/// process (git state is immutable during a single CLI invocation), so
+/// callers iterating over many namespaces pay for each unique prefix
+/// exactly once instead of forking `git describe` per call site.
 pub fn current_semver(prefix: &str) -> String {
+    static CACHE: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(guard) = cache.lock() {
+        if let Some(cached) = guard.get(prefix) {
+            return cached.clone();
+        }
+    }
     let cmd = format!(
         "git describe --match {}-* --tags $(git log -n1 --pretty='%h')",
         prefix
     );
     let out = sh(&cmd, &pwd());
-    if out.contains("fatal") {
+    let v = if out.contains("fatal") {
         String::from("0.0.1")
     } else {
         extract_version(&out)
+    };
+    if let Ok(mut guard) = cache.lock() {
+        guard.insert(prefix.to_string(), v.clone());
     }
+    v
 }

--- a/lib/kit/src/io.rs
+++ b/lib/kit/src/io.rs
@@ -429,7 +429,11 @@ pub fn runv(dir: &str, cmd: Vec<&str>) {
 }
 
 pub fn root() -> String {
-    sh("git rev-parse --show-toplevel", &pwd())
+    use std::sync::OnceLock;
+    static CACHE: OnceLock<String> = OnceLock::new();
+    CACHE
+        .get_or_init(|| sh("git rev-parse --show-toplevel", &pwd()))
+        .clone()
 }
 
 pub fn roots() -> String {

--- a/lib/resolver/src/function.rs
+++ b/lib/resolver/src/function.rs
@@ -357,21 +357,29 @@ pub async fn find_modified(
     topology: &Topology,
 ) -> HashMap<String, Function> {
     let Root {
+        namespace,
         fqn,
         kind,
         version,
-        ..
     } = root;
 
     let maybe_version = snapshotter::find_version(auth, fqn, kind).await;
 
     if let Some(target_version) = maybe_version {
-        let fns = differ::diff_fns(topology, &target_version, &version);
+        // Pass the *root* namespace to diff_fns so git tag construction
+        // uses the namespace where tags actually live. `topology` here may
+        // be a nested node whose own namespace doesn't match any tag.
+        let fns = differ::diff_fns(topology, namespace, &target_version, version);
         if !fns.is_empty() {
-            println!("Diff {} {}..{} ({})", &topology.namespace, &target_version, &version, fns.len());
+            println!(
+                "Diff {} {}..{} ({})",
+                namespace,
+                &target_version,
+                &version,
+                fns.len()
+            );
         }
         fns
-
     } else {
         topology.functions.clone()
     }

--- a/lib/resolver/src/function.rs
+++ b/lib/resolver/src/function.rs
@@ -357,17 +357,17 @@ pub async fn find_modified(
     topology: &Topology,
 ) -> HashMap<String, Function> {
     let Root {
-        namespace,
         fqn,
         kind,
         version,
+        ..
     } = root;
 
     let maybe_version = snapshotter::find_version(auth, fqn, kind).await;
 
     if let Some(target_version) = maybe_version {
-        let fns = differ::diff_fns(&namespace, &target_version, &version, &topology.functions);
-        if fns.len() > 0 {
+        let fns = differ::diff_fns(topology, &target_version, &version);
+        if !fns.is_empty() {
             println!("Diff {} {}..{} ({})", &topology.namespace, &target_version, &version, fns.len());
         }
         fns

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,10 +220,18 @@ pub async fn diff(auth: Auth, sandbox: Option<String>, recursive: bool, _trace: 
 
     let functions = resolver::function::find_modified(&auth, &rt, &topology).await;
     println!("Modified functions:");
-    let mut names: Vec<&String> = functions.keys().collect();
+    let mut names: Vec<String> = functions.keys().cloned().collect();
     names.sort();
-    for name in names {
+    for name in &names {
         println!("{}", name);
+    }
+    for node in topology.nodes.values() {
+        let fns = resolver::function::find_modified(&auth, &rt, node).await;
+        let mut node_names: Vec<String> = fns.keys().cloned().collect();
+        node_names.sort();
+        for name in node_names {
+            println!("{}/{}", node.namespace, name);
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,14 +220,10 @@ pub async fn diff(auth: Auth, sandbox: Option<String>, recursive: bool, _trace: 
 
     let functions = resolver::function::find_modified(&auth, &rt, &topology).await;
     println!("Modified functions:");
-    for (name, _) in functions {
+    let mut names: Vec<&String> = functions.keys().collect();
+    names.sort();
+    for name in names {
         println!("{}", name);
-    }
-    for (_, node) in &topology.nodes {
-        let functions = resolver::function::find_modified(&auth, &rt, &node).await;
-        for (name, _) in functions {
-            println!("{}/{}", node.namespace, name);
-        }
     }
 }
 


### PR DESCRIPTION
Rewrite the differ to mark a function as changed iff a file that actually feeds its code artifact has changed between two tags. Per-function closure = function dir + reachable symlink targets + transitive relative-path refs in manifests (pyproject.toml, Cargo.toml, package.json, Gemfile, requirements*.txt, lockfiles). No hardcoded shared/ paths; no "redeploy everything" fallback.

Recursively traverse topology.nodes so nested topologies' functions are considered. Transducer policy: mark the transducer changed iff anything under its owning topology's dir changed.

Perf: build the git diff once per invocation; walk each unique directory at most once across all functions via a cross-function Analyzer cache; parallelize Function::new in discover_functions and make_nodes with std::thread::scope; cache current_semver by prefix, find_revision by dir, and u::root() process-wide; skip git fetch when the tag is already resolvable locally.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the core logic that determines which functions redeploy, and adds parallel topology/function discovery that could affect determinism and edge-case coverage.
> 
> **Overview**
> Improves `tc` function change detection by switching from directory-prefix heuristics to a **per-function code-dependency closure** model: a function is marked changed only if the git diff intersects its closure (function dir + reachable symlink targets + transitive relative-path references extracted from common manifest/lockfiles).
> 
> The differ now builds the git diff once per invocation, canonicalizes paths, skips redundant tag fetches, and reuses a cross-function `Analyzer` cache so shared dependency directories are walked once; CLI diff output is updated to cover nested `topology.nodes` and include transducers when files under the owning topology directory change.
> 
> Separately, performance tweaks add thread-scoped parallelism for topology node/function discovery and introduce process-wide caching for `u::root()`, `git::current_semver`, and `find_revision`; `walkdir`/`tempfile` are added as dependencies to support the new analysis and tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d81417357285870e4e22b32ec86849bc863f912e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->