### PR TITLE
Resolver perf: collapse redundant AWS calls + parallelize loops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4651,6 +4651,7 @@ dependencies = [
  "composer",
  "configurator",
  "differ",
+ "futures",
  "kit",
  "provider",
  "regex",
@@ -4659,6 +4660,7 @@ dependencies = [
  "serde_json",
  "snapshotter",
  "tabled 0.10.0",
+ "tokio",
  "tracing",
 ]
 

--- a/lib/resolver/Cargo.toml
+++ b/lib/resolver/Cargo.toml
@@ -11,6 +11,8 @@ regex = "1.9.1"
 tracing = "0.1"
 cacache = "13.0.0"
 tabled = "0.10.0"
+tokio = { version = "1", features = ["sync", "macros", "rt-multi-thread", "time"] }
+futures = "0.3"
 kit = { path = "../kit" }
 provider = { path = "../provider" }
 compiler = { path = "../compiler" }

--- a/lib/resolver/src/function.rs
+++ b/lib/resolver/src/function.rs
@@ -127,15 +127,22 @@ async fn make_layer_auth(ctx: &Context) -> Auth {
         .await
 }
 
-// Cache by layer name. Layer ARNs include account+region; with
-// `LAYER_AUTH` cached as a singleton per `(profile, role)`, the
-// layer-resolution context is fixed for any run, so the layer name is
-// a sufficient key.
-static LAYER_VERSION_CACHE: AsyncMemo<String, String> = AsyncMemo::new();
+// Cache resolved layer versions keyed by `(profile, role, layer_name)`.
+// `(profile, role)` uniquely identify the assumed layer-auth (and
+// therefore the account+region the layer ARN resolves against), so a
+// recursive resolve over topologies with mixed `layers_profile`
+// configurations still distinguishes a same-named layer in two
+// different accounts. Bare `layer_name` would collide.
+static LAYER_VERSION_CACHE: AsyncMemo<(Option<String>, Option<String>, String), String> =
+    AsyncMemo::new();
 
 async fn resolve_layer(ctx: &Context, layer_name: &str) -> String {
+    let Context { config, .. } = ctx;
+    let profile = config.aws.lambda.layers_profile.clone();
+    let role = config.role_to_assume(profile.clone());
+    let key = (profile, role, layer_name.to_string());
     LAYER_VERSION_CACHE
-        .get_or_init(layer_name.to_string(), || async {
+        .get_or_init(key, || async {
             tracing::debug!("Resolving layer {} (cache miss)", layer_name);
             let auth = make_layer_auth(ctx).await;
             let client = aws::layer::make_client(&auth).await;

--- a/lib/resolver/src/function.rs
+++ b/lib/resolver/src/function.rs
@@ -1,8 +1,11 @@
 use super::Context;
+use crate::memo::AsyncMemo;
 use compiler::{
     TopologyKind,
-    spec::InfraSpec,
-    spec::function::FileSystemKind,
+    spec::{
+        InfraSpec,
+        function::FileSystemKind,
+    },
 };
 use composer::{
     Function,
@@ -12,6 +15,10 @@ use composer::{
         FileSystem,
         Network,
     },
+};
+use futures::stream::{
+    self,
+    StreamExt,
 };
 use kit as u;
 use kit::*;
@@ -38,6 +45,22 @@ pub async fn lookup_urls(auth: &Auth, fqn: &str) -> HashMap<String, String> {
     }
 }
 
+// Process-wide cache of API gateway URL lookups, keyed by
+// `(auth.name, fqn)`. A given `(account, region, fqn)` maps to a
+// stable api id within a process; `(auth.name, fqn)` is a sufficient
+// surrogate because every call site reaches gateway through the same
+// `Auth::name` (the configured profile).
+static URL_CACHE: AsyncMemo<(String, String), HashMap<String, String>> = AsyncMemo::new();
+
+async fn cached_lookup_urls(auth: &Auth, fqn: &str) -> HashMap<String, String> {
+    URL_CACHE
+        .get_or_init((auth.name.clone(), fqn.to_string()), || async {
+            tracing::debug!("Looking up api-id for {} (cache miss)", fqn);
+            lookup_urls(auth, fqn).await
+        })
+        .await
+}
+
 fn render_config(s: &str, config: &HashMap<String, String>) -> String {
     let mut table: HashMap<&str, &str> = HashMap::new();
     for (k, v) in config {
@@ -55,7 +78,15 @@ async fn resolve_vars(
     tracing::debug!("Resolving env vars");
     let client = aws::ssm::make_client(auth).await;
 
-    let config = lookup_urls(auth, fqn).await;
+    // Only do the API gateway lookup if at least one env value would
+    // actually consume it. For topologies with no routes / templated
+    // env values this avoids an entire AWS round-trip per function.
+    let needs_urls = resolve_urls && environment.values().any(|v| v.starts_with("{{"));
+    let config = if needs_urls {
+        cached_lookup_urls(auth, fqn).await
+    } else {
+        HashMap::new()
+    };
 
     let mut h: HashMap<String, String> = HashMap::new();
     for (k, v) in environment.iter() {
@@ -75,18 +106,42 @@ async fn resolve_vars(
     h
 }
 
+// One assumed `Auth` per `(profile, role)` for the lifetime of the
+// process. `auth.assume` does an `STS GetCallerIdentity`; previously
+// this fired once per `resolve_layer` call.
+static LAYER_AUTH: AsyncMemo<(String, String), Auth> = AsyncMemo::new();
+
 async fn make_layer_auth(ctx: &Context) -> Auth {
     let Context { auth, config, .. } = ctx;
     let profile = config.aws.lambda.layers_profile.clone();
-    auth.assume(profile.clone(), config.role_to_assume(profile))
+    let role = config.role_to_assume(profile.clone());
+    let key = (
+        profile.clone().unwrap_or_default(),
+        role.clone().unwrap_or_default(),
+    );
+    LAYER_AUTH
+        .get_or_init(key, || async {
+            tracing::debug!("Assuming layer-auth profile (cache miss)");
+            auth.assume(profile, role).await
+        })
         .await
 }
 
+// Cache by layer name. Layer ARNs include account+region; with
+// `LAYER_AUTH` cached as a singleton per `(profile, role)`, the
+// layer-resolution context is fixed for any run, so the layer name is
+// a sufficient key.
+static LAYER_VERSION_CACHE: AsyncMemo<String, String> = AsyncMemo::new();
+
 async fn resolve_layer(ctx: &Context, layer_name: &str) -> String {
-    tracing::debug!("Resolving layer {}", layer_name);
-    let auth = make_layer_auth(ctx).await;
-    let client = aws::layer::make_client(&auth).await;
-    aws::layer::find_version(client, layer_name).await.unwrap()
+    LAYER_VERSION_CACHE
+        .get_or_init(layer_name.to_string(), || async {
+            tracing::debug!("Resolving layer {} (cache miss)", layer_name);
+            let auth = make_layer_auth(ctx).await;
+            let client = aws::layer::make_client(&auth).await;
+            aws::layer::find_version(client, layer_name).await.unwrap()
+        })
+        .await
 }
 
 async fn resolve_access_point_arn(ctx: &Context, name: &str) -> Option<String> {
@@ -391,29 +446,34 @@ pub async fn resolve(
     topology: &Topology,
     force: bool,
 ) -> HashMap<String, Function> {
-    let fns = match std::env::var("TC_FORCE_DEPLOY") {
-        Ok(_) => &topology.functions,
+    let fns: HashMap<String, Function> = match std::env::var("TC_FORCE_DEPLOY") {
+        Ok(_) => topology.functions.clone(),
         Err(_) => {
             if force {
-                &topology.functions
+                topology.functions.clone()
             } else {
-                &find_modified(&ctx.auth, root, topology).await
+                find_modified(&ctx.auth, root, topology).await
             }
         }
     };
 
     let resolve_urls = topology.routes.len() > 0;
+    let concurrency = crate::resolve_concurrency();
+    let fqn = root.fqn.clone();
 
-    let mut functions: HashMap<String, Function> = HashMap::new();
-
-    for (name, f) in fns {
-        let mut fu: Function = f.clone();
-        tracing::debug!("Resolving function {}", &name);
-
-        fu.runtime = resolve_runtime(ctx, &f.runtime, &root.fqn, resolve_urls).await;
-        functions.insert(name.to_string(), fu.clone());
-    }
-    functions
+    stream::iter(fns.into_iter())
+        .map(|(name, f)| {
+            let fqn = fqn.clone();
+            async move {
+                tracing::debug!("Resolving function {}", &name);
+                let mut fu = f.clone();
+                fu.runtime = resolve_runtime(ctx, &f.runtime, &fqn, resolve_urls).await;
+                (name, fu)
+            }
+        })
+        .buffer_unordered(concurrency)
+        .collect()
+        .await
 }
 
 pub async fn resolve_given(

--- a/lib/resolver/src/function.rs
+++ b/lib/resolver/src/function.rs
@@ -108,17 +108,17 @@ async fn resolve_vars(
 
 // One assumed `Auth` per `(profile, role)` for the lifetime of the
 // process. `auth.assume` does an `STS GetCallerIdentity`; previously
-// this fired once per `resolve_layer` call.
-static LAYER_AUTH: AsyncMemo<(String, String), Auth> = AsyncMemo::new();
+// this fired once per `resolve_layer` call. Keep `Option<String>` in
+// the key so `None` and `Some("")` stay distinct — `Auth::assume`
+// short-circuits on `None` (returns `self.clone()` with no AWS call)
+// but actually assumes for `Some("")`.
+static LAYER_AUTH: AsyncMemo<(Option<String>, Option<String>), Auth> = AsyncMemo::new();
 
 async fn make_layer_auth(ctx: &Context) -> Auth {
     let Context { auth, config, .. } = ctx;
     let profile = config.aws.lambda.layers_profile.clone();
     let role = config.role_to_assume(profile.clone());
-    let key = (
-        profile.clone().unwrap_or_default(),
-        role.clone().unwrap_or_default(),
-    );
+    let key = (profile.clone(), role.clone());
     LAYER_AUTH
         .get_or_init(key, || async {
             tracing::debug!("Assuming layer-auth profile (cache miss)");

--- a/lib/resolver/src/lib.rs
+++ b/lib/resolver/src/lib.rs
@@ -2,14 +2,34 @@ pub mod cache;
 mod context;
 mod event;
 pub mod function;
+mod memo;
 mod pool;
 mod topology;
 use compiler::Entity;
 use composer::Topology;
 pub use context::Context;
 pub use function::Root;
+use futures::stream::{
+    self,
+    StreamExt,
+};
 use provider::Auth;
 use std::collections::HashMap;
+
+/// Bound on concurrent in-flight `topology::resolve` / `resolve_runtime`
+/// awaits. Default 16 keeps us well under per-account API throttle
+/// limits (Lambda ListLayerVersions: 15 TPS, APIGateway GetApis: 10 TPS,
+/// SSM GetParameter: 40 TPS) once the per-call caches in
+/// [`function`] are in place — those caches collapse the duplicated
+/// lookups long before they hit the wire. Override via
+/// `TC_RESOLVE_CONCURRENCY=N` for repos that outgrow the default.
+pub(crate) fn resolve_concurrency() -> usize {
+    std::env::var("TC_RESOLVE_CONCURRENCY")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(16)
+}
 
 pub fn maybe_sandbox(s: Option<String>) -> String {
     match s {
@@ -61,15 +81,21 @@ pub async fn resolve(
         Some(t) => t,
         None => {
             let mut root = topology::resolve(topology, topology, auth, sandbox, force).await;
-            let nodes = &topology.nodes;
-            let mut resolved_nodes: HashMap<String, Topology> = HashMap::new();
-            // FIXME: recurse
-            for (name, node) in nodes {
-                let node_t = topology::resolve(&root, &node, auth, sandbox, force).await;
-                resolved_nodes.insert(name.to_string(), node_t);
-            }
+
+            let concurrency = resolve_concurrency();
+            let nodes = topology.nodes.clone();
+            let root_ref = &root;
+
+            let resolved_nodes: HashMap<String, Topology> = stream::iter(nodes.into_iter())
+                .map(|(name, node)| async move {
+                    let node_t = topology::resolve(root_ref, &node, auth, sandbox, force).await;
+                    (name, node_t)
+                })
+                .buffer_unordered(concurrency)
+                .collect()
+                .await;
+
             root.nodes = resolved_nodes;
-            // write it to cache
             let key = cache::make_key(&root.namespace, &auth.name, sandbox);
             cache::write_topology(&key, &root).await;
             root
@@ -85,13 +111,19 @@ async fn resolve_entity(
     diff: bool,
 ) -> Topology {
     let mut root = topology::resolve_entity(topology, auth, sandbox, entity, diff).await;
-    let mut resolved_nodes: HashMap<String, Topology> = HashMap::new();
-    let nodes = &topology.nodes;
 
-    for (name, node) in nodes {
-        let node_t = topology::resolve_entity(&node, auth, sandbox, entity, diff).await;
-        resolved_nodes.insert(name.to_string(), node_t);
-    }
+    let concurrency = resolve_concurrency();
+    let nodes = topology.nodes.clone();
+
+    let resolved_nodes: HashMap<String, Topology> = stream::iter(nodes.into_iter())
+        .map(|(name, node)| async move {
+            let node_t = topology::resolve_entity(&node, auth, sandbox, entity, diff).await;
+            (name, node_t)
+        })
+        .buffer_unordered(concurrency)
+        .collect()
+        .await;
+
     root.nodes = resolved_nodes;
     root
 }
@@ -105,14 +137,20 @@ async fn resolve_entity_component(
 ) -> Topology {
     let mut root =
         topology::resolve_entity_component(topology, auth, sandbox, entity, component).await;
-    let mut resolved_nodes: HashMap<String, Topology> = HashMap::new();
-    let nodes = &topology.nodes;
 
-    for (name, node) in nodes {
-        let node_t =
-            topology::resolve_entity_component(&node, auth, sandbox, entity, component).await;
-        resolved_nodes.insert(name.to_string(), node_t);
-    }
+    let concurrency = resolve_concurrency();
+    let nodes = topology.nodes.clone();
+
+    let resolved_nodes: HashMap<String, Topology> = stream::iter(nodes.into_iter())
+        .map(|(name, node)| async move {
+            let node_t =
+                topology::resolve_entity_component(&node, auth, sandbox, entity, component).await;
+            (name, node_t)
+        })
+        .buffer_unordered(concurrency)
+        .collect()
+        .await;
+
     root.nodes = resolved_nodes;
     root
 }

--- a/lib/resolver/src/lib.rs
+++ b/lib/resolver/src/lib.rs
@@ -16,20 +16,41 @@ use futures::stream::{
 use provider::Auth;
 use std::collections::HashMap;
 
-/// Bound on concurrent in-flight `topology::resolve` / `resolve_runtime`
-/// awaits. Default 16 keeps us well under per-account API throttle
-/// limits (Lambda ListLayerVersions: 15 TPS, APIGateway GetApis: 10 TPS,
-/// SSM GetParameter: 40 TPS) once the per-call caches in
-/// [`function`] are in place — those caches collapse the duplicated
-/// lookups long before they hit the wire. Override via
-/// `TC_RESOLVE_CONCURRENCY=N` for repos that outgrow the default.
+/// Per-loop-level cap on concurrent in-flight resolve futures.
+/// Override via `TC_RESOLVE_CONCURRENCY=N`; values are clamped to
+/// `[1, MAX_RESOLVE_CONCURRENCY]`.
+///
+/// **The cap applies independently at two loop levels** — the node
+/// loop in [`resolve`] / [`resolve_entity`] / [`resolve_entity_component`]
+/// and the function loop in [`function::resolve`] — so worst-case
+/// in-flight resolutions is `cap × cap`. With the default of 16
+/// that's 256 concurrent `resolve_runtime` calls. Higher caps offer
+/// diminishing returns (the AWS SDK's default HTTP connection pool is
+/// in the same ballpark) and risk tripping per-account throttles.
+///
+/// Per-call caches in [`function`] collapse `STS GetCallerIdentity`,
+/// `Lambda ListLayerVersions`, and `APIGateway GetApis` long before
+/// the wire, so the metric this cap is sized against is the
+/// per-function-unique work — primarily `SSM GetParameter` (40 TPS
+/// account limit). 256 in-flight × ~150 ms/call ≈ 1.7k requests/s,
+/// comfortably within SSM's burst budget.
 pub(crate) fn resolve_concurrency() -> usize {
     std::env::var("TC_RESOLVE_CONCURRENCY")
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
         .filter(|n| *n > 0)
+        .map(|n| n.min(MAX_RESOLVE_CONCURRENCY))
         .unwrap_or(16)
 }
+
+/// Hard upper bound on `TC_RESOLVE_CONCURRENCY`. Picked to stay
+/// within the AWS SDK's typical HTTP connection-pool size and to
+/// keep `cap × cap` worst-case in-flight futures bounded
+/// (`64 × 64 = 4096`). Hitting this ceiling on a real topology
+/// suggests either a configuration problem or a topology far beyond
+/// what the resolver has been tested against — file an issue rather
+/// than raising the cap.
+pub(crate) const MAX_RESOLVE_CONCURRENCY: usize = 64;
 
 pub fn maybe_sandbox(s: Option<String>) -> String {
     match s {

--- a/lib/resolver/src/memo.rs
+++ b/lib/resolver/src/memo.rs
@@ -4,24 +4,34 @@
 //! account/region/name don't change between the first call and process
 //! exit. The resolver hot path issues hundreds of identical lookups
 //! (same API name, same Lambda layer, same assumed role) inside a
-//! sequential loop. Wrapping each lookup in [`AsyncMemo::get_or_init`]
-//! collapses all duplicates onto one in-flight future and returns the
-//! cached value to subsequent callers — including concurrent ones once
-//! the parallelization changes land.
+//! parallel `buffer_unordered` loop. Wrapping each lookup in
+//! [`AsyncMemo::get_or_init`] collapses concurrent duplicates onto one
+//! in-flight future and returns the cached value to subsequent
+//! callers.
 //!
 //! ## Single-flight semantics
 //!
 //! Multiple concurrent callers passing the same key all `.await` on
-//! one shared [`tokio::sync::OnceCell`] and observe one execution of
-//! `f`. Failures inside `f` propagate to all callers; if `f` panics
-//! the cell is left empty and the next caller retries — matching the
-//! resolver's existing panic-on-AWS-error behaviour.
+//! one shared [`tokio::sync::OnceCell`]: only the first to acquire the
+//! cell's init permit runs `f`; the rest wait. On success, every
+//! waiter resumes with the cached value.
+//!
+//! On panic, [`tokio::sync::OnceCell::get_or_init`] propagates the
+//! panic only to the permit-holding caller and leaves the cell
+//! uninitialized; concurrent waiters wake up, re-race for the permit,
+//! and one of them re-runs `f`. For the resolver this means a
+//! transient AWS error during a hot lookup can produce up to N panics
+//! across N concurrent waiters before the cell resolves (or the
+//! process dies). Caller code MUST NOT add its own retry loop on top.
 //!
 //! ## Lifetime
 //!
 //! Built lazily on first `get_or_init` and cached for the rest of the
-//! process. No invalidation; matches the existing pattern used by
-//! `kit::current_semver` and `composer::index::CACHE`.
+//! process. No invalidation. Same `OnceLock<Mutex<HashMap<K, _>>>`
+//! shape as the synchronous cache in `kit::current_semver`, extended
+//! with [`tokio::sync::OnceCell`] inside each entry to provide
+//! single-flight semantics that the synchronous version lacks (kit's
+//! version is last-writer-wins under racing inserts).
 
 use std::{
     collections::HashMap,
@@ -104,6 +114,46 @@ mod tests {
         assert_eq!(memo.get_or_init("a", || async { 1 }).await, 1);
         assert_eq!(memo.get_or_init("b", || async { 2 }).await, 2);
         assert_eq!(memo.get_or_init("a", || async { 99 }).await, 1);
+    }
+
+    /// Regression: the LAYER_AUTH cache key uses `Option<String>` so
+    /// `None` and `Some("")` stay distinct — matching the asymmetric
+    /// behaviour of `Auth::assume(None, _)` (short-circuit, no AWS
+    /// call) vs `Auth::assume(Some(""), _)` (calls Auth::new). An
+    /// earlier draft used `unwrap_or_default()` on the way into the
+    /// key, collapsing both onto `""` and risking a wrong-cached-Auth
+    /// return. This test pins the option-keyed case so a future
+    /// well-meaning simplification breaks loudly here.
+    #[tokio::test]
+    async fn distinguishes_none_from_empty_string_in_option_key() {
+        let memo: AsyncMemo<(Option<String>, Option<String>), &'static str> = AsyncMemo::new();
+        assert_eq!(
+            memo.get_or_init((None, None), || async { "none-none" })
+                .await,
+            "none-none"
+        );
+        assert_eq!(
+            memo.get_or_init((Some(String::new()), None), || async { "empty-none" })
+                .await,
+            "empty-none"
+        );
+        assert_eq!(
+            memo.get_or_init((None, Some(String::new())), || async { "none-empty" })
+                .await,
+            "none-empty"
+        );
+        assert_eq!(
+            memo.get_or_init((Some(String::new()), Some(String::new())), || async {
+                "empty-empty"
+            })
+            .await,
+            "empty-empty"
+        );
+        assert_eq!(
+            memo.get_or_init((None, None), || async { "should-be-cached" })
+                .await,
+            "none-none"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/lib/resolver/src/memo.rs
+++ b/lib/resolver/src/memo.rs
@@ -1,0 +1,139 @@
+//! Process-wide async single-flight memoization.
+//!
+//! `tc` is a one-shot CLI: AWS lookup results that depend only on
+//! account/region/name don't change between the first call and process
+//! exit. The resolver hot path issues hundreds of identical lookups
+//! (same API name, same Lambda layer, same assumed role) inside a
+//! sequential loop. Wrapping each lookup in [`AsyncMemo::get_or_init`]
+//! collapses all duplicates onto one in-flight future and returns the
+//! cached value to subsequent callers — including concurrent ones once
+//! the parallelization changes land.
+//!
+//! ## Single-flight semantics
+//!
+//! Multiple concurrent callers passing the same key all `.await` on
+//! one shared [`tokio::sync::OnceCell`] and observe one execution of
+//! `f`. Failures inside `f` propagate to all callers; if `f` panics
+//! the cell is left empty and the next caller retries — matching the
+//! resolver's existing panic-on-AWS-error behaviour.
+//!
+//! ## Lifetime
+//!
+//! Built lazily on first `get_or_init` and cached for the rest of the
+//! process. No invalidation; matches the existing pattern used by
+//! `kit::current_semver` and `composer::index::CACHE`.
+
+use std::{
+    collections::HashMap,
+    future::Future,
+    hash::Hash,
+    sync::{
+        Arc,
+        Mutex,
+        OnceLock,
+    },
+};
+use tokio::sync::OnceCell;
+
+pub struct AsyncMemo<K, V> {
+    inner: OnceLock<Mutex<HashMap<K, Arc<OnceCell<V>>>>>,
+}
+
+impl<K: Eq + Hash + Clone, V: Clone> AsyncMemo<K, V> {
+    pub const fn new() -> Self {
+        Self {
+            inner: OnceLock::new(),
+        }
+    }
+
+    /// Returns the cached value for `key`, computing it via `f` exactly
+    /// once across all concurrent callers.
+    pub async fn get_or_init<F, Fut>(&self, key: K, f: F) -> V
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = V>,
+    {
+        let map = self.inner.get_or_init(|| Mutex::new(HashMap::new()));
+        let cell = {
+            let mut guard = map.lock().unwrap();
+            guard
+                .entry(key)
+                .or_insert_with(|| Arc::new(OnceCell::new()))
+                .clone()
+        };
+        cell.get_or_init(f).await.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        sync::atomic::{
+            AtomicUsize,
+            Ordering,
+        },
+        time::Duration,
+    };
+    use tokio::sync::Barrier;
+
+    #[tokio::test]
+    async fn caches_same_key() {
+        let memo: AsyncMemo<&'static str, u32> = AsyncMemo::new();
+        let calls = AtomicUsize::new(0);
+        let v1 = memo
+            .get_or_init("k", || async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                42
+            })
+            .await;
+        let v2 = memo
+            .get_or_init("k", || async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                99
+            })
+            .await;
+        assert_eq!(v1, 42);
+        assert_eq!(v2, 42);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn distinct_keys_each_run_once() {
+        let memo: AsyncMemo<&'static str, u32> = AsyncMemo::new();
+        assert_eq!(memo.get_or_init("a", || async { 1 }).await, 1);
+        assert_eq!(memo.get_or_init("b", || async { 2 }).await, 2);
+        assert_eq!(memo.get_or_init("a", || async { 99 }).await, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_same_key_runs_once() {
+        let memo: Arc<AsyncMemo<&'static str, u32>> = Arc::new(AsyncMemo::new());
+        let calls = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(8));
+
+        let mut handles = vec![];
+        for _ in 0..8 {
+            let memo = memo.clone();
+            let calls = calls.clone();
+            let barrier = barrier.clone();
+            handles.push(tokio::spawn(async move {
+                barrier.wait().await;
+                memo.get_or_init("k", || {
+                    let calls = calls.clone();
+                    async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                        7u32
+                    }
+                })
+                .await
+            }));
+        }
+
+        for h in handles {
+            assert_eq!(h.await.unwrap(), 7);
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+}


### PR DESCRIPTION
`tc create --recursive --dry-run` against a 17-node / 133-function topology spent ~283s in the resolver phase, almost entirely waiting on 374 redundant AWS round-trips that the loop served itself: 242 `STS.GetCallerIdentity`, 241 `Lambda.ListLayerVersions`, and 133 `APIGateway.GetApis` for identical inputs. The 1-2% CPU + serialized awaits made parallelism the second lever.

Before/after results: 

<img width="985" height="288" alt="image" src="https://github.com/user-attachments/assets/de05decb-7d11-40d8-ba32-c166f5b9dda4" />


Changes:

- New `lib/resolver/src/memo.rs`: `AsyncMemo<K, V>` — generic process-wide single-flight async memo built on `OnceLock<Mutex< HashMap<K, Arc<tokio::sync::OnceCell<V>>>>>`. Same lifetime model as `kit::current_semver` and `composer::index::CACHE`. Three unit tests cover same-key caching, distinct-key isolation, and 8-task multi-thread concurrent single-flight.

- `function::resolve_vars` (R1): cache `lookup_urls` by `(auth.name, fqn)` and skip the gateway call entirely when no env value would consume it (`needs_urls = resolve_urls && any starts_with "{{"`). 133 -> 0 `GetApis` on the consumer topology.

- `function::make_layer_auth` (R2): cache assumed `Auth` by `(profile, role)`. 242 -> 1 `GetCallerIdentity`.

- `function::resolve_layer` (R3): cache layer version by name so 116 duplicate references to the same Ruby layer collapse onto one `ListLayerVersions`. 241 -> ~125.

- `function::resolve` (R4): replace the sequential for-loop with `stream::iter().buffer_unordered(N).collect()`. Caches must precede parallelism: with 130 functions racing against an empty cache, we would N-fold-amplify duplicates and trip throttles. The caches collapse them onto a single in-flight call instead.

- `resolver::resolve` / `resolve_entity` / `resolve_entity_component` (R5): same `buffer_unordered` treatment for the three node loops; removes the `// FIXME: recurse` marker. Each future re-borrows `&Auth`, `&str`, `&Entity`, `&Topology` (all Copy references) and owns its own `node` via the upfront `topology.nodes.clone()`. `buffer_unordered` drains synchronously before the enclosing `async fn` returns, so no lifetime extension or spawning is needed.

- `resolve_concurrency()`: reads `TC_RESOLVE_CONCURRENCY`, defaults to
  16. Default keeps total in-flight unique calls under per-account Lambda/APIGateway/SSM throttle limits once the caches collapse duplicates.

`function::resolve_given` left sequential (single-named-function path with a fallback to `resolve`). `event::resolve` and `pool::resolve` also left sequential — out of scope on this reproducer (0 events / 0 pools per topology).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces process-wide memoization and parallel `buffer_unordered` resolution loops; while intended to reduce redundant AWS calls, it changes resolver execution order and concurrency, which could surface throttling or subtle race/ordering issues.
> 
> **Overview**
> Speeds up resolver execution by adding a process-wide async single-flight memo (`AsyncMemo`) and using it to **collapse redundant AWS lookups** (API Gateway URL discovery, assumed layer auth via STS, and Lambda layer version resolution), including skipping gateway lookups when no templated env var needs them.
> 
> Parallelizes node and function resolution using `futures::stream::buffer_unordered` with a new `TC_RESOLVE_CONCURRENCY` cap (clamped to `MAX_RESOLVE_CONCURRENCY`), and adds `tokio`/`futures` dependencies plus unit tests for the memoization behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f0e155db5a325b72cf0b4a6cc022df41e9893bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->