### PR TITLE
Shared function dedup

### DIFF
--- a/lib/composer/src/aws/function.rs
+++ b/lib/composer/src/aws/function.rs
@@ -36,6 +36,16 @@ pub struct Function {
     pub build: Build,
     pub test: HashMap<String, TestSpec>,
     pub targets: Vec<Target>,
+
+    /// True iff this `Function` was declared in a topology's `functions:`
+    /// block via a relative `uri:` (i.e. shared between topologies).
+    /// Used by `composer::topology::promote_shared_to_root` to dedupe
+    /// shared imports up to the root of a recursive composition.
+    /// `#[serde(default)]` keeps existing resolver-cache JSON entries
+    /// (which lack this field) backward-compatible: they deserialize
+    /// with `shared = false`, equivalent to "not shared".
+    #[serde(default)]
+    pub shared: bool,
 }
 
 fn is_singular_function_dir() -> bool {
@@ -135,6 +145,7 @@ impl Function {
             test: make_test(fspec.test),
             runtime: runtime,
             targets: targets,
+            shared: false,
         }
     }
 
@@ -174,6 +185,7 @@ impl Function {
             test: make_test(fspec.test.clone()),
             runtime: runtime,
             targets: targets,
+            shared: false,
         }
     }
 

--- a/lib/composer/src/aws/function.rs
+++ b/lib/composer/src/aws/function.rs
@@ -37,13 +37,7 @@ pub struct Function {
     pub test: HashMap<String, TestSpec>,
     pub targets: Vec<Target>,
 
-    /// True iff this `Function` was declared in a topology's `functions:`
-    /// block via a relative `uri:` (i.e. shared between topologies).
-    /// Used by `composer::topology::promote_shared_to_root` to dedupe
-    /// shared imports up to the root of a recursive composition.
-    /// `#[serde(default)]` keeps existing resolver-cache JSON entries
-    /// (which lack this field) backward-compatible: they deserialize
-    /// with `shared = false`, equivalent to "not shared".
+    /// Marks functions imported via relative `uri:` for dedup promotion to root.
     #[serde(default)]
     pub shared: bool,
 }

--- a/lib/composer/src/aws/transducer.rs
+++ b/lib/composer/src/aws/transducer.rs
@@ -215,6 +215,7 @@ fn make_function(namespace: &str, name: &str, fqn: &str) -> Function {
         layer_name: None,
         targets: vec![],
         test: HashMap::new(),
+        shared: false,
     }
 }
 

--- a/lib/composer/src/topology.rs
+++ b/lib/composer/src/topology.rs
@@ -1046,15 +1046,6 @@ mod tests {
     use std::os::unix::fs::symlink;
     use tempfile::TempDir;
 
-    /// Regression: when pwd reaches the repo root via a symlink (e.g.
-    /// macOS `/tmp` → `/private/tmp`), `make_nodes` was passing the
-    /// non-canonical `root_dir` to `should_ignore_node` while
-    /// `nested_topology_dirs` returned canonical paths from the
-    /// `composer::index`. The `nodes.ignore` and `.tcignore` rules
-    /// silently failed to match because the prefix-equality /
-    /// `starts_with` checks compared `/tmp/...` against
-    /// `/private/tmp/...`. `should_ignore_node` now canonicalises both
-    /// sides before comparing.
     #[test]
     fn should_ignore_node_matches_when_root_reached_via_symlink() {
         let outer = TempDir::new().unwrap();
@@ -1080,6 +1071,248 @@ mod tests {
         assert!(
             !should_ignore_node(alias_root, ignore, canonical_keep_str),
             "non-matching dir should not be ignored"
+        );
+    }
+
+use tempfile::TempDir;
+
+    /// Minimum function.yml that satisfies `FunctionSpec::new` →
+    /// `Runtime::new` → `make_lambda` without panicking. `fqn:` is set
+    /// so all importers compute the same final fqn (`shared_foo_<sandbox>`)
+    /// regardless of which node's namespace was passed in to `make_fqn`,
+    /// which mirrors how shared functions are written in real codebases.
+    fn write_shared_function(dir: &std::path::Path, name: &str, fqn: &str) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(
+            dir.join("function.yml"),
+            format!(
+                "name: {name}\n\
+                 fqn: {fqn}\n\
+                 runtime:\n  \
+                   lang: python3.10\n  \
+                   handler: handler.handler\n  \
+                   package_type: zip\n  \
+                   layers: []\n\
+                 build:\n  \
+                   kind: Code\n  \
+                   command: echo build\n"
+            ),
+        )
+        .unwrap();
+        // Satisfy `is_inferred_dir`. Empty file is fine — we never invoke
+        // the build pipeline, just discover/intern.
+        fs::write(dir.join("handler.py"), "").unwrap();
+    }
+
+    fn write_topology_yml(dir: &std::path::Path, contents: &str) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(dir.join("topology.yml"), contents).unwrap();
+    }
+
+    /// Reproduces the consumer-extraction shape that triggered the
+    /// shared-function rebuild bug: a parent topology with multiple
+    /// nested topologies, each declaring the same shared function via
+    /// a relative `uri:` in its `functions:` block. After recursive
+    /// composition, the shared function must appear exactly once at
+    /// root and zero times in any descendant.
+    ///
+    /// Also covers, in the same fixture:
+    /// - A second shared function imported by a subset of nodes
+    ///   (verifies the post-pass dedupes per-key, not per-node).
+    /// - A descendant with its own non-shared function declared inline
+    ///   (verifies that owned functions are preserved in place).
+    /// - JSON round-trip of a promoted Function with the `shared` field
+    ///   stripped (regression guard for the `#[serde(default)]`
+    ///   attribute on `Function.shared`).
+    #[test]
+    fn compose_recursive_dedups_shared_functions_to_root() {
+        let outer = TempDir::new().unwrap();
+        let root = outer.path();
+
+        // Parent topology — no inline functions, no flow.
+        write_topology_yml(
+            root,
+            "name: shared-dedup-parent\nkind: step-function\n",
+        );
+
+        // Two shared function source dirs, both imported by descendants.
+        write_shared_function(&root.join("shared/foo"), "foo", "shared_foo");
+        write_shared_function(&root.join("shared/bar"), "bar", "shared_bar");
+
+        // Three child topologies, all importing `foo`. Only `c` also
+        // imports `bar`. `c` additionally declares its own non-shared
+        // function `local`, to confirm the post-pass leaves owned
+        // entries in place.
+        write_topology_yml(
+            &root.join("a"),
+            "name: child-a\nkind: step-function\nfunctions:\n  foo:\n    uri: ../shared/foo\n",
+        );
+        write_topology_yml(
+            &root.join("b"),
+            "name: child-b\nkind: step-function\nfunctions:\n  foo:\n    uri: ../shared/foo\n",
+        );
+        write_topology_yml(
+            &root.join("c"),
+            "name: child-c\n\
+             kind: step-function\n\
+             functions:\n  \
+               foo:\n    uri: ../shared/foo\n  \
+               bar:\n    uri: ../shared/bar\n",
+        );
+        // c's own non-shared function lives at c/local/. Discovered, not interned.
+        write_shared_function(&root.join("c/local"), "local", "child_c_local");
+
+        let topology = Topology::new(root.to_str().unwrap(), true, false);
+
+        // Root owns both shared functions exactly once each.
+        assert!(
+            topology.functions.contains_key("foo"),
+            "shared function `foo` must be promoted to root.functions; root has {:?}",
+            topology.functions.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            topology.functions.contains_key("bar"),
+            "shared function `bar` must be promoted to root.functions; root has {:?}",
+            topology.functions.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            topology
+                .functions
+                .get("foo")
+                .map(|f| f.shared)
+                .unwrap_or(false),
+            "promoted `foo` retains shared = true"
+        );
+        assert!(
+            topology
+                .functions
+                .get("bar")
+                .map(|f| f.shared)
+                .unwrap_or(false),
+            "promoted `bar` retains shared = true"
+        );
+
+        // No descendant retains either shared function (search the full
+        // descendant tree, not just direct children, since
+        // `discover_leaf_nodes` mirrors each node into its own
+        // `node.nodes` map and a future refactor could turn this into
+        // genuine multi-level nesting).
+        fn collect_offenders(
+            t: &Topology,
+            path: String,
+            keys: &[&'static str],
+            out: &mut Vec<(String, &'static str)>,
+        ) {
+            for k in keys {
+                if t.functions.contains_key(*k) {
+                    out.push((path.clone(), *k));
+                }
+            }
+            for (name, child) in &t.nodes {
+                collect_offenders(child, format!("{path}/{name}"), keys, out);
+            }
+        }
+
+        let mut offenders: Vec<(String, &'static str)> = Vec::new();
+        for (name, child) in &topology.nodes {
+            collect_offenders(child, name.clone(), &["foo", "bar"], &mut offenders);
+        }
+        assert!(
+            offenders.is_empty(),
+            "no descendant should retain a shared function; found: {:?}",
+            offenders
+        );
+
+        // Three nested topologies must be present at root level
+        // (`make_nodes` flattens the WalkDir result, so all three are
+        // direct children of root regardless of fs depth).
+        let child_namespaces: std::collections::BTreeSet<&String> =
+            topology.nodes.keys().collect();
+        assert!(
+            child_namespaces.contains(&s!("child-a")),
+            "child-a missing; root.nodes = {:?}",
+            child_namespaces
+        );
+        assert!(
+            child_namespaces.contains(&s!("child-b")),
+            "child-b missing; root.nodes = {:?}",
+            child_namespaces
+        );
+        assert!(
+            child_namespaces.contains(&s!("child-c")),
+            "child-c missing; root.nodes = {:?}",
+            child_namespaces
+        );
+
+        // child-c's own non-shared `local` function survives the
+        // promotion pass with shared = false.
+        let child_c = topology
+            .nodes
+            .get("child-c")
+            .expect("child-c node present");
+        let local = child_c
+            .functions
+            .get("local")
+            .expect("child-c retains its own `local` function after promotion");
+        assert!(
+            !local.shared,
+            "child-c's own `local` function must have shared = false"
+        );
+
+        // Resolver-cache backwards-compat: a Function serialized to
+        // JSON with the `shared` key stripped (legacy entry) must
+        // deserialize cleanly with shared = false. Validates the
+        // `#[serde(default)]` attribute on Function.shared.
+        let foo = topology.functions.get("foo").unwrap();
+        let mut value = serde_json::to_value(foo).expect("Function serializes to JSON");
+        let removed = value
+            .as_object_mut()
+            .expect("Function JSON is an object")
+            .remove("shared");
+        assert!(
+            removed.is_some(),
+            "freshly serialized Function must include `shared` key"
+        );
+        let legacy: Function = serde_json::from_value(value)
+            .expect("Function JSON missing `shared` must deserialize via #[serde(default)]");
+        assert!(
+            !legacy.shared,
+            "missing `shared` field must default to false on legacy resolver-cache JSON"
+        );
+    }
+
+    /// `intern_functions` reads the topology spec's `functions:` block.
+    /// For inline declarations whose `uri:` starts with `.` (relative),
+    /// the produced `Function` must carry `shared = true`. For inline
+    /// declarations without a `uri:`, or with one that doesn't start
+    /// with `.`, the function is treated as a normal in-tree function
+    /// and must carry `shared = false`.
+    ///
+    /// Exercised end-to-end via the fixture above (each child's
+    /// `foo`/`bar` is shared, `child-c/local` is not). This stub
+    /// directly inspects the fixture's outputs without a separate
+    /// fixture for clarity / fewer dependencies on `TopologySpec`
+    /// internals (`TopologySpec` does not implement `Default`, so a
+    /// pure unit test would have to manually populate every field).
+    #[test]
+    fn intern_marks_relative_uri_imports_as_shared() {
+        let outer = TempDir::new().unwrap();
+        let root = outer.path();
+        write_topology_yml(root, "name: parent\nkind: step-function\n");
+        write_shared_function(&root.join("shared/x"), "x", "shared_x");
+        write_topology_yml(
+            &root.join("a"),
+            "name: child-a\nkind: step-function\nfunctions:\n  x:\n    uri: ../shared/x\n",
+        );
+
+        let topology = Topology::new(root.to_str().unwrap(), true, false);
+        let promoted = topology
+            .functions
+            .get("x")
+            .expect("relatively-imported function must end up at root");
+        assert!(
+            promoted.shared,
+            "relative-uri import must have shared = true after promotion"
         );
     }
 }

--- a/lib/composer/src/topology.rs
+++ b/lib/composer/src/topology.rs
@@ -963,22 +963,24 @@ impl Topology {
             let infra_dir = as_infra_dir(spec.infra.to_owned(), dir);
             tracing::debug!("Infra dir: {}  {}", &spec.name, &infra_dir);
 
-            let nodes;
-            if recursive {
+            let nodes = if recursive {
                 tracing::debug!("Recursive {}", dir);
-                nodes = make_nodes(dir, &spec);
+                make_nodes(dir, &spec)
             } else {
-                nodes = HashMap::new();
-            }
-            if skip_functions {
+                HashMap::new()
+            };
+            let mut topology = if skip_functions {
                 tracing::debug!("Skipping functions {}", dir);
-                let functions = HashMap::new();
-                make(dir, dir, &spec, functions, nodes)
+                make(dir, dir, &spec, HashMap::new(), nodes)
             } else {
                 tracing::debug!("Discovering functions {}", dir);
                 let functions = discover_functions(dir, &infra_dir, &spec);
                 make(dir, dir, &spec, functions, nodes)
+            };
+            if recursive {
+                promote_shared_to_root(&mut topology);
             }
+            topology
         } else if is_relative_topology_dir(dir) {
             make_relative(dir)
         } else if is_standalone_function_dir(dir) {

--- a/lib/composer/src/topology.rs
+++ b/lib/composer/src/topology.rs
@@ -836,42 +836,13 @@ pub fn is_compilable(dir: &str) -> bool {
     is_standalone_function_dir(dir) || is_relative_topology_dir(dir) || is_topology_dir(dir)
 }
 
-// Shared-function deduplication: single-owner promotion to root.
-//
-// `intern_functions` materialises a fresh `Function` into the importing
-// node's `functions` map for every entry whose `uri:` is a relative path
-// (see `is_shared`). Without dedup, when N nested topologies import the
-// same shared function, the resulting recursive `Topology` contains N
-// copies — one per importer — and `tc create` ends up running N full
-// Docker builds + N redundant `lambda:CreateFunction`/`UpdateFunctionCode`
-// calls against the same `fqn`.
-//
-// The fix is a post-pass over the recursively-built root topology that
-// drains every `Function` with `shared = true` out of each descendant's
-// `functions` map and inserts it into `root.functions`, deduped by
-// HashMap key. After this pass:
-//
-//   - `root.functions` contains every shared function exactly once
-//   - each descendant's `functions` map contains only its own (non-shared)
-//     entries
-//   - downstream callers (`deployer::create`, `builder::build_recursive`,
-//     `function::resolve`, etc.) deploy/build/resolve each shared
-//     function exactly once.
-//
-// The promotion runs only when `Topology::new` is constructing a
-// recursive root topology. Non-recursive callers (single-leaf modes
-// like `tc compose` on one node, `current_function`, `is_compilable`)
-// don't have descendants to dedupe against.
-
-/// Recursively drains all `shared` functions out of `node` and its
-/// descendants into `target`. Conflicts (same map key) resolve to
-/// `target`'s existing entry; identical-fqn collisions are silent,
-/// fqn-mismatched collisions emit `tracing::debug!` so latent name
-/// collisions don't go unnoticed. Each topology's own (non-shared)
-/// functions are preserved in place.
-fn drain_shared_into(target: &mut HashMap<String, Function>, node: &mut Topology) {
+/// Recursively drains `shared` functions from `node` and descendants into
+/// `target`, deduped by key (first wins). Returns the number of duplicates
+/// encountered (already present in `target`).
+fn drain_shared_into(target: &mut HashMap<String, Function>, node: &mut Topology) -> usize {
+    let mut duplicates = 0usize;
     for child in node.nodes.values_mut() {
-        drain_shared_into(target, child);
+        duplicates += drain_shared_into(target, child);
     }
     let drained = std::mem::take(&mut node.functions);
     let mut owned: HashMap<String, Function> = HashMap::with_capacity(drained.len());
@@ -879,6 +850,7 @@ fn drain_shared_into(target: &mut HashMap<String, Function>, node: &mut Topology
         if f.shared {
             match target.entry(name.clone()) {
                 std::collections::hash_map::Entry::Occupied(existing) => {
+                    duplicates += 1;
                     if existing.get().fqn != f.fqn {
                         tracing::debug!(
                             "shared-function key collision: {} ({} vs {}) — keeping existing",
@@ -897,38 +869,13 @@ fn drain_shared_into(target: &mut HashMap<String, Function>, node: &mut Topology
         }
     }
     node.functions = owned;
+    duplicates
 }
 
-/// Counts every `shared = true` function in `t` and all its descendants.
-/// Used purely for the post-promotion log line that reports how many
-/// duplicate imports were eliminated.
-fn count_shared_recursive(t: &Topology) -> usize {
-    let here = t.functions.values().filter(|f| f.shared).count();
-    let descendants: usize = t.nodes.values().map(count_shared_recursive).sum();
-    here + descendants
-}
-
-/// Recompute every topology's `roles` map from its post-promotion
-/// `functions` map and `flow`. Necessary because `make()` calls
-/// `make_roles` *before* `promote_shared_to_root` runs, leaving the
-/// `roles` maps stale relative to the new `functions` shape:
-///
-/// - Root's `roles` is missing the shared functions' roles (root
-///   didn't own those functions when `make_roles` ran).
-/// - Each descendant's `roles` still contains the shared functions'
-///   roles (the descendant owned them at make-time but no longer
-///   does after promotion).
-///
-/// Without this pass, a fresh `tc create` deploys root first
-/// (`deployer::create` calls `role::create_or_update` then
-/// `function::create`); since root's IAM roles for the shared
-/// functions don't exist yet, AWS rejects the Lambda creation calls
-/// (the Lambdas reference role ARNs that haven't been provisioned).
-///
-/// Recomputation is fully equivalent to the original computation:
-/// `make_roles` is a pure function of `(functions, flow)`, both of
-/// which are stable through promotion (only the *placement* of
-/// functions changes, never their `runtime.role` payload).
+/// Recompute `roles` at every level from current `(functions, flow)`.
+/// Necessary because `make()` computed roles before promotion relocated
+/// shared functions, leaving root missing their roles and descendants
+/// holding stale entries.
 fn recompute_roles_recursive(t: &mut Topology) {
     for child in t.nodes.values_mut() {
         recompute_roles_recursive(child);
@@ -936,51 +883,27 @@ fn recompute_roles_recursive(t: &mut Topology) {
     t.roles = make_roles(&t.functions, &0, &0, &0, &t.flow);
 }
 
-/// Single-owner invariant: after this call, every `Function` with
-/// `shared = true` lives in `root.functions`, every descendant's
-/// `functions` map contains only that descendant's own (non-shared)
-/// functions, and every topology's `roles` map matches its current
-/// `functions` map.
-///
-/// Conflict semantics (`or_insert` via `Entry::Vacant`):
-///
-/// - Two siblings declare the same shared function → first one wins,
-///   others dropped. Equivalent because they all reference the same
-///   source dir.
-/// - Root *and* a node declare the same shared function → root's entry
-///   wins. Same source dir, equivalent.
-/// - Two functions with the same map key but different `fqn`s → first
-///   one wins, others dropped. Doesn't happen in practice (keys are
-///   local function names and shared functions have a single canonical
-///   `function.yml`); emits `tracing::debug!` if it ever does.
+/// Drain all `shared` functions from descendants into `root.functions`
+/// (first-wins on key collision) and recompute roles at every level.
 pub(crate) fn promote_shared_to_root(root: &mut Topology) {
-    let nodes_count = root.nodes.len();
-    let before: usize = root
-        .nodes
-        .values()
-        .map(count_shared_recursive)
-        .sum();
     let mut promoted: HashMap<String, Function> = HashMap::new();
+    let mut duplicates = 0usize;
     for child in root.nodes.values_mut() {
-        drain_shared_into(&mut promoted, child);
+        duplicates += drain_shared_into(&mut promoted, child);
+    }
+    if promoted.is_empty() {
+        return;
     }
     let promoted_count = promoted.len();
     for (name, f) in promoted {
         root.functions.entry(name).or_insert(f);
     }
-    // `make_roles` ran inside each `make()` call before this pass, so
-    // every topology's `roles` map is now stale w.r.t. its current
-    // `functions` map. Restore the invariant before downstream
-    // consumers (deployer, builder, etc.) read the topology.
     recompute_roles_recursive(root);
-    if before > 0 {
-        tracing::info!(
-            "Promoted {} unique shared function(s) from {} node(s) to root (eliminated {} duplicate import(s))",
-            promoted_count,
-            nodes_count,
-            before.saturating_sub(promoted_count),
-        );
-    }
+    tracing::info!(
+        "Promoted {} shared function(s) to root (eliminated {} duplicate(s))",
+        promoted_count,
+        duplicates,
+    );
 }
 
 impl Topology {
@@ -1108,13 +1031,6 @@ mod tests {
         );
     }
 
-use tempfile::TempDir;
-
-    /// Minimum function.yml that satisfies `FunctionSpec::new` →
-    /// `Runtime::new` → `make_lambda` without panicking. `fqn:` is set
-    /// so all importers compute the same final fqn (`shared_foo_<sandbox>`)
-    /// regardless of which node's namespace was passed in to `make_fqn`,
-    /// which mirrors how shared functions are written in real codebases.
     fn write_shared_function(dir: &std::path::Path, name: &str, fqn: &str) {
         fs::create_dir_all(dir).unwrap();
         fs::write(
@@ -1133,8 +1049,6 @@ use tempfile::TempDir;
             ),
         )
         .unwrap();
-        // Satisfy `is_inferred_dir`. Empty file is fine — we never invoke
-        // the build pipeline, just discover/intern.
         fs::write(dir.join("handler.py"), "").unwrap();
     }
 
@@ -1143,40 +1057,19 @@ use tempfile::TempDir;
         fs::write(dir.join("topology.yml"), contents).unwrap();
     }
 
-    /// Reproduces the consumer-extraction shape that triggered the
-    /// shared-function rebuild bug: a parent topology with multiple
-    /// nested topologies, each declaring the same shared function via
-    /// a relative `uri:` in its `functions:` block. After recursive
-    /// composition, the shared function must appear exactly once at
-    /// root and zero times in any descendant.
-    ///
-    /// Also covers, in the same fixture:
-    /// - A second shared function imported by a subset of nodes
-    ///   (verifies the post-pass dedupes per-key, not per-node).
-    /// - A descendant with its own non-shared function declared inline
-    ///   (verifies that owned functions are preserved in place).
-    /// - JSON round-trip of a promoted Function with the `shared` field
-    ///   stripped (regression guard for the `#[serde(default)]`
-    ///   attribute on `Function.shared`).
     #[test]
     fn compose_recursive_dedups_shared_functions_to_root() {
         let outer = TempDir::new().unwrap();
         let root = outer.path();
 
-        // Parent topology — no inline functions, no flow.
         write_topology_yml(
             root,
             "name: shared-dedup-parent\nkind: step-function\n",
         );
 
-        // Two shared function source dirs, both imported by descendants.
         write_shared_function(&root.join("shared/foo"), "foo", "shared_foo");
         write_shared_function(&root.join("shared/bar"), "bar", "shared_bar");
 
-        // Three child topologies, all importing `foo`. Only `c` also
-        // imports `bar`. `c` additionally declares its own non-shared
-        // function `local`, to confirm the post-pass leaves owned
-        // entries in place.
         write_topology_yml(
             &root.join("a"),
             "name: child-a\nkind: step-function\nfunctions:\n  foo:\n    uri: ../shared/foo\n",
@@ -1193,12 +1086,10 @@ use tempfile::TempDir;
                foo:\n    uri: ../shared/foo\n  \
                bar:\n    uri: ../shared/bar\n",
         );
-        // c's own non-shared function lives at c/local/. Discovered, not interned.
         write_shared_function(&root.join("c/local"), "local", "child_c_local");
 
         let topology = Topology::new(root.to_str().unwrap(), true, false);
 
-        // Root owns both shared functions exactly once each.
         assert!(
             topology.functions.contains_key("foo"),
             "shared function `foo` must be promoted to root.functions; root has {:?}",
@@ -1226,11 +1117,6 @@ use tempfile::TempDir;
             "promoted `bar` retains shared = true"
         );
 
-        // No descendant retains either shared function (search the full
-        // descendant tree, not just direct children, since
-        // `discover_leaf_nodes` mirrors each node into its own
-        // `node.nodes` map and a future refactor could turn this into
-        // genuine multi-level nesting).
         fn collect_offenders(
             t: &Topology,
             path: String,
@@ -1257,9 +1143,6 @@ use tempfile::TempDir;
             offenders
         );
 
-        // Three nested topologies must be present at root level
-        // (`make_nodes` flattens the WalkDir result, so all three are
-        // direct children of root regardless of fs depth).
         let child_namespaces: std::collections::BTreeSet<&String> =
             topology.nodes.keys().collect();
         assert!(
@@ -1278,8 +1161,6 @@ use tempfile::TempDir;
             child_namespaces
         );
 
-        // child-c's own non-shared `local` function survives the
-        // promotion pass with shared = false.
         let child_c = topology
             .nodes
             .get("child-c")
@@ -1293,14 +1174,6 @@ use tempfile::TempDir;
             "child-c's own `local` function must have shared = false"
         );
 
-        // Roles invariant: every non-`provided` role referenced by
-        // `root.functions` must live in `root.roles` after promotion.
-        // Before the role-recompute fix, root.roles was computed from
-        // root.functions *before* promotion (so it didn't contain
-        // shared functions' roles), which would cause `deployer::create`
-        // to skip provisioning those roles and AWS to reject the
-        // shared Lambdas' creation. This assertion is the regression
-        // guard.
         for (fname, f) in &topology.functions {
             if f.runtime.role.kind.to_str() != "provided" {
                 assert!(
@@ -1313,14 +1186,6 @@ use tempfile::TempDir;
                 );
             }
         }
-        // Symmetrically, no descendant's `roles` should reference a
-        // function it no longer owns. For each descendant, every entry
-        // in its `roles` map must correspond to either (a) one of its
-        // own functions, or (b) its own state-machine flow's role.
-        // Stale entries — most commonly the shared functions' roles
-        // left behind when their functions were promoted away — would
-        // cause each node deploy to redundantly create-or-update
-        // roles already provisioned by root.
         fn assert_roles_match_functions(t: &Topology, path: &str) {
             for (rname, _) in &t.roles {
                 let owned_by_function = t
@@ -1349,10 +1214,6 @@ use tempfile::TempDir;
             assert_roles_match_functions(child, name);
         }
 
-        // Resolver-cache backwards-compat: a Function serialized to
-        // JSON with the `shared` key stripped (legacy entry) must
-        // deserialize cleanly with shared = false. Validates the
-        // `#[serde(default)]` attribute on Function.shared.
         let foo = topology.functions.get("foo").unwrap();
         let mut value = serde_json::to_value(foo).expect("Function serializes to JSON");
         let removed = value
@@ -1371,19 +1232,6 @@ use tempfile::TempDir;
         );
     }
 
-    /// `intern_functions` reads the topology spec's `functions:` block.
-    /// For inline declarations whose `uri:` starts with `.` (relative),
-    /// the produced `Function` must carry `shared = true`. For inline
-    /// declarations without a `uri:`, or with one that doesn't start
-    /// with `.`, the function is treated as a normal in-tree function
-    /// and must carry `shared = false`.
-    ///
-    /// Exercised end-to-end via the fixture above (each child's
-    /// `foo`/`bar` is shared, `child-c/local` is not). This stub
-    /// directly inspects the fixture's outputs without a separate
-    /// fixture for clarity / fewer dependencies on `TopologySpec`
-    /// internals (`TopologySpec` does not implement `Default`, so a
-    /// pure unit test would have to manually populate every field).
     #[test]
     fn intern_marks_relative_uri_imports_as_shared() {
         let outer = TempDir::new().unwrap();
@@ -1403,6 +1251,123 @@ use tempfile::TempDir;
         assert!(
             promoted.shared,
             "relative-uri import must have shared = true after promotion"
+        );
+    }
+
+    #[test]
+    fn root_declaring_shared_function_keeps_it_in_place() {
+        let outer = TempDir::new().unwrap();
+        let root = outer.path();
+        write_shared_function(&root.join("shared/x"), "x", "shared_x");
+        write_topology_yml(
+            root,
+            "name: root-shared\nkind: step-function\nfunctions:\n  x:\n    uri: ./shared/x\n",
+        );
+
+        let topology = Topology::new(root.to_str().unwrap(), true, false);
+        assert!(
+            topology.functions.contains_key("x"),
+            "root's own shared function must remain in root.functions"
+        );
+        assert!(
+            topology.functions.get("x").unwrap().shared,
+            "root's own shared function retains shared = true"
+        );
+    }
+
+    #[test]
+    fn same_source_different_keys_both_promoted() {
+        let outer = TempDir::new().unwrap();
+        let root = outer.path();
+        write_topology_yml(root, "name: parent\nkind: step-function\n");
+        write_shared_function(&root.join("shared/foo"), "foo", "shared_foo");
+        write_topology_yml(
+            &root.join("a"),
+            "name: child-a\nkind: step-function\nfunctions:\n  foo:\n    uri: ../shared/foo\n",
+        );
+        write_topology_yml(
+            &root.join("b"),
+            "name: child-b\nkind: step-function\nfunctions:\n  my_foo:\n    uri: ../shared/foo\n",
+        );
+
+        let topology = Topology::new(root.to_str().unwrap(), true, false);
+
+        assert!(
+            topology.functions.contains_key("foo"),
+            "key `foo` must be promoted"
+        );
+        assert!(
+            topology.functions.contains_key("my_foo"),
+            "key `my_foo` must be promoted (same source, different local name)"
+        );
+        assert_eq!(
+            topology.functions.get("foo").unwrap().dir,
+            topology.functions.get("my_foo").unwrap().dir,
+            "both keys reference the same source dir"
+        );
+    }
+
+    #[test]
+    fn deep_nesting_shared_functions_promoted() {
+        let outer = TempDir::new().unwrap();
+        let root = outer.path();
+        write_topology_yml(root, "name: parent\nkind: step-function\n");
+        write_shared_function(&root.join("shared/foo"), "foo", "shared_foo");
+
+        // Two levels: root -> mid -> leaf, leaf imports shared function
+        write_topology_yml(
+            &root.join("mid"),
+            "name: mid\nkind: step-function\n",
+        );
+        write_topology_yml(
+            &root.join("mid/leaf"),
+            "name: leaf\nkind: step-function\nfunctions:\n  foo:\n    uri: ../../shared/foo\n",
+        );
+
+        let topology = Topology::new(root.to_str().unwrap(), true, false);
+
+        assert!(
+            topology.functions.contains_key("foo"),
+            "shared function from deep nesting must be promoted to root"
+        );
+
+        fn has_shared_function(t: &Topology, key: &str) -> bool {
+            if t.functions.contains_key(key) {
+                return true;
+            }
+            t.nodes.values().any(|child| has_shared_function(child, key))
+        }
+        for child in topology.nodes.values() {
+            assert!(
+                !has_shared_function(child, "foo"),
+                "no descendant should retain the shared function"
+            );
+        }
+    }
+
+    #[test]
+    fn non_recursive_mode_does_not_promote() {
+        let outer = TempDir::new().unwrap();
+        let root = outer.path();
+        write_shared_function(&root.join("shared/x"), "x", "shared_x");
+        write_topology_yml(
+            root,
+            "name: non-recursive\nkind: step-function\nfunctions:\n  x:\n    uri: ./shared/x\n",
+        );
+
+        let topology = Topology::new(root.to_str().unwrap(), false, false);
+
+        assert!(
+            topology.functions.contains_key("x"),
+            "function present in non-recursive mode"
+        );
+        assert!(
+            topology.functions.get("x").unwrap().shared,
+            "shared flag is set even in non-recursive mode (marking is unconditional)"
+        );
+        assert!(
+            topology.nodes.is_empty(),
+            "non-recursive mode has no child nodes"
         );
     }
 }

--- a/lib/composer/src/topology.rs
+++ b/lib/composer/src/topology.rs
@@ -213,7 +213,8 @@ fn intern_functions(
                 None => root_namespace,
             };
 
-            let function = Function::new(&abs_dir, infra_dir, &namespace, spec.fmt());
+            let mut function = Function::new(&abs_dir, infra_dir, &namespace, spec.fmt());
+            function.shared = true;
             fns.insert(s!(name), function);
         } else {
             let dir = format!("{}/{}", root_dir, name);

--- a/lib/composer/src/topology.rs
+++ b/lib/composer/src/topology.rs
@@ -908,10 +908,39 @@ fn count_shared_recursive(t: &Topology) -> usize {
     here + descendants
 }
 
+/// Recompute every topology's `roles` map from its post-promotion
+/// `functions` map and `flow`. Necessary because `make()` calls
+/// `make_roles` *before* `promote_shared_to_root` runs, leaving the
+/// `roles` maps stale relative to the new `functions` shape:
+///
+/// - Root's `roles` is missing the shared functions' roles (root
+///   didn't own those functions when `make_roles` ran).
+/// - Each descendant's `roles` still contains the shared functions'
+///   roles (the descendant owned them at make-time but no longer
+///   does after promotion).
+///
+/// Without this pass, a fresh `tc create` deploys root first
+/// (`deployer::create` calls `role::create_or_update` then
+/// `function::create`); since root's IAM roles for the shared
+/// functions don't exist yet, AWS rejects the Lambda creation calls
+/// (the Lambdas reference role ARNs that haven't been provisioned).
+///
+/// Recomputation is fully equivalent to the original computation:
+/// `make_roles` is a pure function of `(functions, flow)`, both of
+/// which are stable through promotion (only the *placement* of
+/// functions changes, never their `runtime.role` payload).
+fn recompute_roles_recursive(t: &mut Topology) {
+    for child in t.nodes.values_mut() {
+        recompute_roles_recursive(child);
+    }
+    t.roles = make_roles(&t.functions, &0, &0, &0, &t.flow);
+}
+
 /// Single-owner invariant: after this call, every `Function` with
-/// `shared = true` lives in `root.functions`, and every descendant's
+/// `shared = true` lives in `root.functions`, every descendant's
 /// `functions` map contains only that descendant's own (non-shared)
-/// functions.
+/// functions, and every topology's `roles` map matches its current
+/// `functions` map.
 ///
 /// Conflict semantics (`or_insert` via `Entry::Vacant`):
 ///
@@ -939,6 +968,11 @@ pub(crate) fn promote_shared_to_root(root: &mut Topology) {
     for (name, f) in promoted {
         root.functions.entry(name).or_insert(f);
     }
+    // `make_roles` ran inside each `make()` call before this pass, so
+    // every topology's `roles` map is now stale w.r.t. its current
+    // `functions` map. Restore the invariant before downstream
+    // consumers (deployer, builder, etc.) read the topology.
+    recompute_roles_recursive(root);
     if before > 0 {
         tracing::info!(
             "Promoted {} unique shared function(s) from {} node(s) to root (eliminated {} duplicate import(s))",
@@ -1258,6 +1292,62 @@ use tempfile::TempDir;
             !local.shared,
             "child-c's own `local` function must have shared = false"
         );
+
+        // Roles invariant: every non-`provided` role referenced by
+        // `root.functions` must live in `root.roles` after promotion.
+        // Before the role-recompute fix, root.roles was computed from
+        // root.functions *before* promotion (so it didn't contain
+        // shared functions' roles), which would cause `deployer::create`
+        // to skip provisioning those roles and AWS to reject the
+        // shared Lambdas' creation. This assertion is the regression
+        // guard.
+        for (fname, f) in &topology.functions {
+            if f.runtime.role.kind.to_str() != "provided" {
+                assert!(
+                    topology.roles.contains_key(&f.runtime.role.name),
+                    "role `{}` for function `{}` must be present in root.roles \
+                     after promotion; root.roles keys = {:?}",
+                    &f.runtime.role.name,
+                    fname,
+                    topology.roles.keys().collect::<Vec<_>>()
+                );
+            }
+        }
+        // Symmetrically, no descendant's `roles` should reference a
+        // function it no longer owns. For each descendant, every entry
+        // in its `roles` map must correspond to either (a) one of its
+        // own functions, or (b) its own state-machine flow's role.
+        // Stale entries — most commonly the shared functions' roles
+        // left behind when their functions were promoted away — would
+        // cause each node deploy to redundantly create-or-update
+        // roles already provisioned by root.
+        fn assert_roles_match_functions(t: &Topology, path: &str) {
+            for (rname, _) in &t.roles {
+                let owned_by_function = t
+                    .functions
+                    .values()
+                    .any(|f| &f.runtime.role.name == rname);
+                let owned_by_flow = t
+                    .flow
+                    .as_ref()
+                    .map(|fl| &fl.role.name == rname)
+                    .unwrap_or(false);
+                assert!(
+                    owned_by_function || owned_by_flow,
+                    "stale role `{}` in {}/roles after promotion (no matching \
+                     function or flow); functions = {:?}",
+                    rname,
+                    path,
+                    t.functions.keys().collect::<Vec<_>>()
+                );
+            }
+            for (name, child) in &t.nodes {
+                assert_roles_match_functions(child, &format!("{path}/{name}"));
+            }
+        }
+        for (name, child) in &topology.nodes {
+            assert_roles_match_functions(child, name);
+        }
 
         // Resolver-cache backwards-compat: a Function serialized to
         // JSON with the `shared` key stripped (legacy entry) must

--- a/lib/composer/src/topology.rs
+++ b/lib/composer/src/topology.rs
@@ -836,6 +836,119 @@ pub fn is_compilable(dir: &str) -> bool {
     is_standalone_function_dir(dir) || is_relative_topology_dir(dir) || is_topology_dir(dir)
 }
 
+// Shared-function deduplication: single-owner promotion to root.
+//
+// `intern_functions` materialises a fresh `Function` into the importing
+// node's `functions` map for every entry whose `uri:` is a relative path
+// (see `is_shared`). Without dedup, when N nested topologies import the
+// same shared function, the resulting recursive `Topology` contains N
+// copies — one per importer — and `tc create` ends up running N full
+// Docker builds + N redundant `lambda:CreateFunction`/`UpdateFunctionCode`
+// calls against the same `fqn`.
+//
+// The fix is a post-pass over the recursively-built root topology that
+// drains every `Function` with `shared = true` out of each descendant's
+// `functions` map and inserts it into `root.functions`, deduped by
+// HashMap key. After this pass:
+//
+//   - `root.functions` contains every shared function exactly once
+//   - each descendant's `functions` map contains only its own (non-shared)
+//     entries
+//   - downstream callers (`deployer::create`, `builder::build_recursive`,
+//     `function::resolve`, etc.) deploy/build/resolve each shared
+//     function exactly once.
+//
+// The promotion runs only when `Topology::new` is constructing a
+// recursive root topology. Non-recursive callers (single-leaf modes
+// like `tc compose` on one node, `current_function`, `is_compilable`)
+// don't have descendants to dedupe against.
+
+/// Recursively drains all `shared` functions out of `node` and its
+/// descendants into `target`. Conflicts (same map key) resolve to
+/// `target`'s existing entry; identical-fqn collisions are silent,
+/// fqn-mismatched collisions emit `tracing::debug!` so latent name
+/// collisions don't go unnoticed. Each topology's own (non-shared)
+/// functions are preserved in place.
+fn drain_shared_into(target: &mut HashMap<String, Function>, node: &mut Topology) {
+    for child in node.nodes.values_mut() {
+        drain_shared_into(target, child);
+    }
+    let drained = std::mem::take(&mut node.functions);
+    let mut owned: HashMap<String, Function> = HashMap::with_capacity(drained.len());
+    for (name, f) in drained {
+        if f.shared {
+            match target.entry(name.clone()) {
+                std::collections::hash_map::Entry::Occupied(existing) => {
+                    if existing.get().fqn != f.fqn {
+                        tracing::debug!(
+                            "shared-function key collision: {} ({} vs {}) — keeping existing",
+                            name,
+                            existing.get().fqn,
+                            f.fqn
+                        );
+                    }
+                }
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert(f);
+                }
+            }
+        } else {
+            owned.insert(name, f);
+        }
+    }
+    node.functions = owned;
+}
+
+/// Counts every `shared = true` function in `t` and all its descendants.
+/// Used purely for the post-promotion log line that reports how many
+/// duplicate imports were eliminated.
+fn count_shared_recursive(t: &Topology) -> usize {
+    let here = t.functions.values().filter(|f| f.shared).count();
+    let descendants: usize = t.nodes.values().map(count_shared_recursive).sum();
+    here + descendants
+}
+
+/// Single-owner invariant: after this call, every `Function` with
+/// `shared = true` lives in `root.functions`, and every descendant's
+/// `functions` map contains only that descendant's own (non-shared)
+/// functions.
+///
+/// Conflict semantics (`or_insert` via `Entry::Vacant`):
+///
+/// - Two siblings declare the same shared function → first one wins,
+///   others dropped. Equivalent because they all reference the same
+///   source dir.
+/// - Root *and* a node declare the same shared function → root's entry
+///   wins. Same source dir, equivalent.
+/// - Two functions with the same map key but different `fqn`s → first
+///   one wins, others dropped. Doesn't happen in practice (keys are
+///   local function names and shared functions have a single canonical
+///   `function.yml`); emits `tracing::debug!` if it ever does.
+pub(crate) fn promote_shared_to_root(root: &mut Topology) {
+    let nodes_count = root.nodes.len();
+    let before: usize = root
+        .nodes
+        .values()
+        .map(count_shared_recursive)
+        .sum();
+    let mut promoted: HashMap<String, Function> = HashMap::new();
+    for child in root.nodes.values_mut() {
+        drain_shared_into(&mut promoted, child);
+    }
+    let promoted_count = promoted.len();
+    for (name, f) in promoted {
+        root.functions.entry(name).or_insert(f);
+    }
+    if before > 0 {
+        tracing::info!(
+            "Promoted {} unique shared function(s) from {} node(s) to root (eliminated {} duplicate import(s))",
+            promoted_count,
+            nodes_count,
+            before.saturating_sub(promoted_count),
+        );
+    }
+}
+
 impl Topology {
     pub fn new(dir: &str, recursive: bool, skip_functions: bool) -> Topology {
         if is_singular_function_dir() {

--- a/lib/composer/src/topology.rs
+++ b/lib/composer/src/topology.rs
@@ -885,7 +885,7 @@ fn recompute_roles_recursive(t: &mut Topology) {
 
 /// Drain all `shared` functions from descendants into `root.functions`
 /// (first-wins on key collision) and recompute roles at every level.
-pub(crate) fn promote_shared_to_root(root: &mut Topology) {
+fn promote_shared_to_root(root: &mut Topology) {
     let mut promoted: HashMap<String, Function> = HashMap::new();
     let mut duplicates = 0usize;
     for child in root.nodes.values_mut() {
@@ -1213,6 +1213,19 @@ mod tests {
         for (name, child) in &topology.nodes {
             assert_roles_match_functions(child, name);
         }
+    }
+
+    #[test]
+    fn shared_field_defaults_to_false_on_legacy_json() {
+        let outer = TempDir::new().unwrap();
+        let root = outer.path();
+        write_topology_yml(root, "name: serde-test\nkind: step-function\n");
+        write_shared_function(&root.join("shared/foo"), "foo", "shared_foo");
+        write_topology_yml(
+            &root.join("a"),
+            "name: child-a\nkind: step-function\nfunctions:\n  foo:\n    uri: ../shared/foo\n",
+        );
+        let topology = Topology::new(root.to_str().unwrap(), true, false);
 
         let foo = topology.functions.get("foo").unwrap();
         let mut value = serde_json::to_value(foo).expect("Function serializes to JSON");


### PR DESCRIPTION
In topologies with shared functions, that shared function ends up getting deployed several times. This PR avoids that, so not only do we avoid unnecessary work, but we'll cut down (and significantly so in some cases) on deploy times as well

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recursive topology composition by relocating functions and recalculating `roles`, which can affect what gets deployed and what IAM roles are generated; behavior is guarded to recursive mode but could impact existing compositions relying on per-node duplication.
> 
> **Overview**
> Prevents duplicate deployment of functions imported via relative `uri:` by adding a `Function.shared` flag (serde-defaulted for legacy cache JSON) and marking relative-uri imports as shared during `intern_functions`.
> 
> When composing recursively, shared functions are now **promoted from descendant topologies into `root.functions`** (first-wins on key collisions), removed from children, and `roles` are recomputed across the tree to avoid missing/stale IAM role entries. Extensive new tests cover promotion/dedup behavior, deep nesting, key-collision scenarios, non-recursive behavior, and legacy deserialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c82d5ad46992efb9d6433d2d2c5e26153b00065b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->