### PR TITLE
Detect aux config file changes (role/vars JSON) in differ

### DIFF
--- a/lib/composer/src/aws/function.rs
+++ b/lib/composer/src/aws/function.rs
@@ -13,6 +13,7 @@ use compiler::spec::{
 use configurator::Config;
 use kit as u;
 use kit::*;
+use runtime::collect_aux_files;
 pub use runtime::Runtime;
 use serde_derive::{
     Deserialize,
@@ -36,10 +37,35 @@ pub struct Function {
     pub build: Build,
     pub test: HashMap<String, TestSpec>,
     pub targets: Vec<Target>,
-
     /// Marks functions imported via relative `uri:` for dedup promotion to root.
     #[serde(default)]
     pub shared: bool,
+    /// Absolute paths of files outside `f.dir` whose contents the
+    /// composer read while constructing this function: role JSON,
+    /// vars JSON, inherited parent `roles/function.json`, etc. Used
+    /// by the differ to widen the per-function closure beyond the
+    /// source-code closure — a change to any of these files marks the
+    /// function dirty even when no source code changed.
+    ///
+    /// Conventional paths (`{infra_dir}/roles/{name}.json`,
+    /// `{infra_dir}/vars/{name}.json`) are always present, even when
+    /// the file doesn't currently exist on disk, so deletions
+    /// (visible in `git diff` as removed paths) still flip the
+    /// function dirty. Explicit overrides (`r.role_file`,
+    /// `r.vars_file`) are present only when they were actually used
+    /// by the composer.
+    ///
+    /// Lives on `Function` rather than on `Runtime` because these are
+    /// source-tree paths on the developer's machine — the deployed
+    /// Lambda runtime never sees them. They're a sibling of `dir`,
+    /// not part of the runtime config.
+    ///
+    /// Populated by `collect_aux_files` during compose. Defaults to an
+    /// empty `Vec` so resolver-cached topologies pre-dating this field
+    /// continue to deserialize cleanly (they degrade to today's
+    /// behavior for that one cache hit; the next compose repopulates).
+    #[serde(default)]
+    pub aux_files: Vec<String>,
 }
 
 fn is_singular_function_dir() -> bool {
@@ -122,6 +148,12 @@ impl Function {
         };
 
         let runtime = Runtime::new(dir, infra_dir, &namespace, &fspec, &fqn, &config);
+        let aux_files = collect_aux_files(
+            infra_dir,
+            &fspec,
+            fspec.runtime.as_ref(),
+            &runtime.role,
+        );
 
         let targets = Target::make_all(&fspec);
 
@@ -140,6 +172,7 @@ impl Function {
             runtime: runtime,
             targets: targets,
             shared: false,
+            aux_files: aux_files,
         }
     }
 
@@ -162,6 +195,12 @@ impl Function {
         };
 
         let runtime = Runtime::new(dir, infra_dir, &namespace, &fspec, &fqn, &config);
+        let aux_files = collect_aux_files(
+            infra_dir,
+            fspec,
+            fspec.runtime.as_ref(),
+            &runtime.role,
+        );
 
         let targets = Target::make_all(&fspec);
 
@@ -180,6 +219,7 @@ impl Function {
             runtime: runtime,
             targets: targets,
             shared: false,
+            aux_files: aux_files,
         }
     }
 

--- a/lib/composer/src/aws/function/runtime.rs
+++ b/lib/composer/src/aws/function/runtime.rs
@@ -67,26 +67,6 @@ pub struct Runtime {
     pub role: Role,
     pub infra_spec: HashMap<String, InfraSpec>,
     pub cluster: String,
-    /// Absolute paths of files outside `f.dir` whose contents are baked
-    /// into the function's deployed configuration: role JSON, vars JSON,
-    /// inherited parent `roles/function.json`, etc. Used by the differ
-    /// to widen the per-function closure beyond the source-code closure.
-    /// A change to any of these files marks the function dirty even when
-    /// no source code changed.
-    ///
-    /// Conventional paths (`{infra_dir}/roles/{name}.json`,
-    /// `{infra_dir}/vars/{name}.json`) are always present, even when the
-    /// file doesn't currently exist on disk, so deletions (visible in
-    /// `git diff` as removed paths) still flip the function dirty.
-    /// Explicit overrides (`r.role_file`, `r.vars_file`) are present
-    /// only when they were actually used by the composer.
-    ///
-    /// Populated by `collect_aux_files` during compose. Defaults to an
-    /// empty `Vec` so resolver-cached topologies pre-dating this field
-    /// continue to deserialize cleanly (they degrade to today's
-    /// behavior for that one cache hit; the next compose repopulates).
-    #[serde(default)]
-    pub aux_files: Vec<String>,
 }
 
 fn find_git_sha(dir: &str) -> String {
@@ -527,7 +507,13 @@ fn lookup_infraspec_default(infra_dir: &str, function_name: &str) -> HashMap<Str
 /// currently uses that pattern. If support is needed later, enumerate
 /// the per-profile variants here — the differ side requires no
 /// changes; just lengthen this list.
-fn collect_aux_files(
+///
+/// Exposed to the parent `function` module so that `Function::new`
+/// (which lives one layer up) can attach the result to the `Function`
+/// itself rather than to `Runtime` — the paths are source-tree
+/// metadata for the differ, not anything the deployed Lambda runtime
+/// consumes.
+pub(super) fn collect_aux_files(
     infra_dir: &str,
     fspec: &FunctionSpec,
     rspec: Option<&RuntimeSpec>,
@@ -573,7 +559,6 @@ fn make_default(
 ) -> Runtime {
     let lang = infer_lang(dir);
     let role = Role::default(Entity::Function);
-    let aux_files = collect_aux_files(infra_dir, fspec, None, &role);
     let infra_spec = lookup_infraspec_default(infra_dir, &fspec.name);
     let default_infra_spec = infra_spec.get("default").unwrap();
 
@@ -615,7 +600,6 @@ fn make_default(
         fs: None,
         infra_spec: infra_spec,
         cluster: String::from(""),
-        aux_files: aux_files,
     }
 }
 
@@ -640,7 +624,6 @@ fn make_lambda(
     let uri = as_uri(dir, namespace, &fspec.name, &package_type, r.uri.clone());
     let enable_fs = needs_fs(fspec.assets.clone(), r.mount_fs, &r.fs);
     let role = lookup_role(&infra_dir, &r, namespace, fqn, &fspec.name);
-    let aux_files = collect_aux_files(infra_dir, fspec, Some(r), &role);
 
     let infra_spec = lookup_infraspec(infra_dir, &fspec.name, r);
     let default_infra_spec = infra_spec.get("default").unwrap();
@@ -683,7 +666,6 @@ fn make_lambda(
         fs: make_fs(&default_infra_spec, &r.fs, enable_fs),
         infra_spec: infra_spec,
         cluster: String::from(""),
-        aux_files: aux_files,
     }
 }
 
@@ -706,7 +688,6 @@ fn make_fargate(
         rspec.uri.clone(),
     );
     let role = lookup_role(&infra_dir, &rspec, namespace, fqn, &fspec.name);
-    let aux_files = collect_aux_files(infra_dir, fspec, Some(rspec), &role);
     let infra_spec = lookup_infraspec(infra_dir, &fspec.name, &rspec);
     let default_infra_spec = infra_spec.get("default").unwrap();
 
@@ -753,7 +734,6 @@ fn make_fargate(
         fs: make_fs(&default_infra_spec, &rspec.fs, enable_fs),
         infra_spec: infra_spec,
         cluster: cluster.to_string(),
-        aux_files: aux_files,
     }
 }
 

--- a/lib/composer/src/aws/function/runtime.rs
+++ b/lib/composer/src/aws/function/runtime.rs
@@ -67,6 +67,26 @@ pub struct Runtime {
     pub role: Role,
     pub infra_spec: HashMap<String, InfraSpec>,
     pub cluster: String,
+    /// Absolute paths of files outside `f.dir` whose contents are baked
+    /// into the function's deployed configuration: role JSON, vars JSON,
+    /// inherited parent `roles/function.json`, etc. Used by the differ
+    /// to widen the per-function closure beyond the source-code closure.
+    /// A change to any of these files marks the function dirty even when
+    /// no source code changed.
+    ///
+    /// Conventional paths (`{infra_dir}/roles/{name}.json`,
+    /// `{infra_dir}/vars/{name}.json`) are always present, even when the
+    /// file doesn't currently exist on disk, so deletions (visible in
+    /// `git diff` as removed paths) still flip the function dirty.
+    /// Explicit overrides (`r.role_file`, `r.vars_file`) are present
+    /// only when they were actually used by the composer.
+    ///
+    /// Populated by `collect_aux_files` during compose. Defaults to an
+    /// empty `Vec` so resolver-cached topologies pre-dating this field
+    /// continue to deserialize cleanly (they degrade to today's
+    /// behavior for that one cache hit; the next compose repopulates).
+    #[serde(default)]
+    pub aux_files: Vec<String>,
 }
 
 fn find_git_sha(dir: &str) -> String {
@@ -484,6 +504,66 @@ fn lookup_infraspec_default(infra_dir: &str, function_name: &str) -> HashMap<Str
     InfraSpec::new(infra_spec_file.clone())
 }
 
+/// Compute the list of files outside the function's source-code closure
+/// whose contents flow into the deployed Lambda configuration. The
+/// differ widens its per-function closure with these so that a change
+/// to any of them marks the function dirty.
+///
+/// The conventional `{infra_dir}/roles/{name}.json` and
+/// `{infra_dir}/vars/{name}.json` paths are emitted unconditionally,
+/// even when the file doesn't currently exist on disk. This is what
+/// makes the deletion case work: when a role file existed at tag A and
+/// was deleted at tag B, the diff-set entry (a logical join produced
+/// by `build_diff_set` when canonicalize fails) byte-matches the path
+/// emitted here, so the function is correctly flagged.
+///
+/// Explicit overrides (`r.role_file`, `r.vars_file`) are only included
+/// when actually present on the spec; the inherited parent
+/// `roles/function.json` is included only when it currently resolves on
+/// disk, since the parent walk has no fixed conventional location.
+///
+/// NOTE: profile-suffixed vars files (e.g. `vars/foo-prod.json`,
+/// `vars/foo-dev.json`) are NOT included here. No production topology
+/// currently uses that pattern. If support is needed later, enumerate
+/// the per-profile variants here — the differ side requires no
+/// changes; just lengthen this list.
+fn collect_aux_files(
+    infra_dir: &str,
+    fspec: &FunctionSpec,
+    rspec: Option<&RuntimeSpec>,
+    role: &Role,
+) -> Vec<String> {
+    let mut out: Vec<String> = vec![];
+
+    out.push(follow_path(&format!(
+        "{}/roles/{}.json",
+        infra_dir, &fspec.name
+    )));
+
+    if !role.path.is_empty() {
+        out.push(role.path.clone());
+    }
+
+    if let Some(p) = find_parent_function_role(infra_dir) {
+        out.push(p);
+    }
+
+    out.push(follow_path(&format!(
+        "{}/vars/{}.json",
+        infra_dir, &fspec.name
+    )));
+
+    if let Some(rs) = rspec {
+        if let Some(p) = &rs.vars_file {
+            out.push(follow_path(p));
+        }
+    }
+
+    out.sort();
+    out.dedup();
+    out
+}
+
 fn make_default(
     dir: &str,
     infra_dir: &str,
@@ -493,6 +573,7 @@ fn make_default(
 ) -> Runtime {
     let lang = infer_lang(dir);
     let role = Role::default(Entity::Function);
+    let aux_files = collect_aux_files(infra_dir, fspec, None, &role);
     let infra_spec = lookup_infraspec_default(infra_dir, &fspec.name);
     let default_infra_spec = infra_spec.get("default").unwrap();
 
@@ -534,6 +615,7 @@ fn make_default(
         fs: None,
         infra_spec: infra_spec,
         cluster: String::from(""),
+        aux_files: aux_files,
     }
 }
 
@@ -558,6 +640,7 @@ fn make_lambda(
     let uri = as_uri(dir, namespace, &fspec.name, &package_type, r.uri.clone());
     let enable_fs = needs_fs(fspec.assets.clone(), r.mount_fs, &r.fs);
     let role = lookup_role(&infra_dir, &r, namespace, fqn, &fspec.name);
+    let aux_files = collect_aux_files(infra_dir, fspec, Some(r), &role);
 
     let infra_spec = lookup_infraspec(infra_dir, &fspec.name, r);
     let default_infra_spec = infra_spec.get("default").unwrap();
@@ -600,6 +683,7 @@ fn make_lambda(
         fs: make_fs(&default_infra_spec, &r.fs, enable_fs),
         infra_spec: infra_spec,
         cluster: String::from(""),
+        aux_files: aux_files,
     }
 }
 
@@ -622,6 +706,7 @@ fn make_fargate(
         rspec.uri.clone(),
     );
     let role = lookup_role(&infra_dir, &rspec, namespace, fqn, &fspec.name);
+    let aux_files = collect_aux_files(infra_dir, fspec, Some(rspec), &role);
     let infra_spec = lookup_infraspec(infra_dir, &fspec.name, &rspec);
     let default_infra_spec = infra_spec.get("default").unwrap();
 
@@ -668,6 +753,7 @@ fn make_fargate(
         fs: make_fs(&default_infra_spec, &rspec.fs, enable_fs),
         infra_spec: infra_spec,
         cluster: cluster.to_string(),
+        aux_files: aux_files,
     }
 }
 
@@ -703,5 +789,338 @@ impl Runtime {
             }
             None => make_default(dir, &infra_dir, namespace, fqn, fspec),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aws::role::Role;
+    use compiler::spec::function::{
+        FunctionSpec,
+        LangRuntime,
+        Provider,
+        RuntimeSpec,
+    };
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use tempfile::TempDir;
+
+    fn fake_fspec(name: &str) -> FunctionSpec {
+        FunctionSpec {
+            name: name.to_string(),
+            dir: None,
+            description: None,
+            namespace: None,
+            fqn: None,
+            layer_name: None,
+            version: None,
+            revision: None,
+            runtime: None,
+            build: None,
+            infra: None,
+            test: None,
+            infra_dir: None,
+            tasks: HashMap::new(),
+            assets: None,
+            targets: None,
+        }
+    }
+
+    fn fake_rspec_no_overrides() -> RuntimeSpec {
+        RuntimeSpec {
+            lang: LangRuntime::Python310,
+            handler: s!("handler.handler"),
+            package_type: None,
+            provider: Some(Provider::Lambda),
+            vars_file: None,
+            role_file: None,
+            role_name: None,
+            role: None,
+            uri: None,
+            mount_fs: None,
+            fs: None,
+            snapstart: None,
+            layers: vec![],
+            extensions: vec![],
+        }
+    }
+
+    fn fake_role_no_path() -> Role {
+        Role::default(Entity::Function)
+    }
+
+    fn fake_role_with_path(path: &str) -> Role {
+        let mut r = Role::default(Entity::Function);
+        r.path = path.to_string();
+        r
+    }
+
+    fn mkdir(root: &Path, rel: &str) {
+        fs::create_dir_all(root.join(rel)).unwrap();
+    }
+
+    fn mkfile(root: &Path, rel: &str, contents: &str) {
+        let p = root.join(rel);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(p, contents).unwrap();
+    }
+
+    /// Conventional `{infra_dir}/roles/{name}.json` must always be in
+    /// `aux_files`, even when the file doesn't exist on disk. This is
+    /// what makes the deletion case work.
+    #[test]
+    fn runtime_aux_files_includes_conventional_role_path() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkdir(root, "infrastructure/tc/foo");
+        let infra_dir = root.join("infrastructure/tc/foo").to_str().unwrap().to_string();
+
+        let aux = collect_aux_files(
+            &infra_dir,
+            &fake_fspec("myfn"),
+            None,
+            &fake_role_no_path(),
+        );
+
+        let expected = format!("{}/roles/myfn.json", infra_dir);
+        assert!(
+            aux.contains(&expected),
+            "expected {} in aux_files; got {:?}",
+            expected,
+            aux
+        );
+    }
+
+    /// Conventional `{infra_dir}/vars/{name}.json` must always be in
+    /// `aux_files`, even when the file doesn't exist on disk.
+    #[test]
+    fn runtime_aux_files_includes_conventional_vars_path() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkdir(root, "infrastructure/tc/foo");
+        let infra_dir = root.join("infrastructure/tc/foo").to_str().unwrap().to_string();
+
+        let aux = collect_aux_files(
+            &infra_dir,
+            &fake_fspec("myfn"),
+            None,
+            &fake_role_no_path(),
+        );
+
+        let expected = format!("{}/vars/myfn.json", infra_dir);
+        assert!(
+            aux.contains(&expected),
+            "expected {} in aux_files; got {:?}",
+            expected,
+            aux
+        );
+    }
+
+    /// When the composer resolves an explicit role override (`r.role`
+    /// or a custom role_file on disk), `Role.path` carries the resolved
+    /// path. `collect_aux_files` must surface it so a change to that
+    /// file flags the function.
+    #[test]
+    fn runtime_aux_files_picks_up_explicit_role_override() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkdir(root, "infrastructure/tc/foo");
+        let infra_dir = root.join("infrastructure/tc/foo").to_str().unwrap().to_string();
+        let override_path = root.join("shared/role.json").to_str().unwrap().to_string();
+
+        let aux = collect_aux_files(
+            &infra_dir,
+            &fake_fspec("myfn"),
+            Some(&fake_rspec_no_overrides()),
+            &fake_role_with_path(&override_path),
+        );
+
+        assert!(
+            aux.contains(&override_path),
+            "expected override path {} in aux_files; got {:?}",
+            override_path,
+            aux
+        );
+    }
+
+    /// When a function has `r.vars_file` set explicitly, that path must
+    /// also land in `aux_files` (after being absolutized through
+    /// `follow_path` if it's a `..`-relative override).
+    #[test]
+    fn runtime_aux_files_picks_up_explicit_vars_override() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkdir(root, "infrastructure/tc/foo");
+        let infra_dir = root.join("infrastructure/tc/foo").to_str().unwrap().to_string();
+        let vars_path = root.join("shared/vars.json").to_str().unwrap().to_string();
+
+        let mut rspec = fake_rspec_no_overrides();
+        rspec.vars_file = Some(vars_path.clone());
+
+        let aux = collect_aux_files(
+            &infra_dir,
+            &fake_fspec("myfn"),
+            Some(&rspec),
+            &fake_role_no_path(),
+        );
+
+        assert!(
+            aux.contains(&vars_path),
+            "expected vars override {} in aux_files; got {:?}",
+            vars_path,
+            aux
+        );
+    }
+
+    /// When an inherited parent `roles/function.json` exists in the
+    /// infra ancestry, `collect_aux_files` must record its path.
+    /// Otherwise a change to a shared parent role wouldn't flag any of
+    /// the descendant functions that fall back to it.
+    #[test]
+    fn runtime_aux_files_picks_up_inherited_parent_role() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkdir(root, "infrastructure/tc/foo");
+        mkfile(root, "infrastructure/tc/roles/function.json", "{}");
+        let infra_dir = root.join("infrastructure/tc/foo").to_str().unwrap().to_string();
+
+        let aux = collect_aux_files(
+            &infra_dir,
+            &fake_fspec("myfn"),
+            None,
+            &fake_role_no_path(),
+        );
+
+        let parent_role = root
+            .join("infrastructure/tc/roles/function.json")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(
+            aux.iter().any(|p| p == &parent_role),
+            "expected inherited parent role {} in aux_files; got {:?}",
+            parent_role,
+            aux
+        );
+    }
+
+    /// `collect_aux_files` sorts and dedupes its output.
+    #[test]
+    fn runtime_aux_files_dedupes_and_sorts() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkdir(root, "infrastructure/tc/foo");
+        let infra_dir = root.join("infrastructure/tc/foo").to_str().unwrap().to_string();
+
+        // Force a duplicate by setting the override role to the same
+        // path as the conventional location.
+        let conventional = format!("{}/roles/myfn.json", infra_dir);
+
+        let aux = collect_aux_files(
+            &infra_dir,
+            &fake_fspec("myfn"),
+            Some(&fake_rspec_no_overrides()),
+            &fake_role_with_path(&conventional),
+        );
+
+        let mut sorted = aux.clone();
+        sorted.sort();
+        assert_eq!(aux, sorted, "aux_files must be sorted");
+
+        let count = aux.iter().filter(|p| **p == conventional).count();
+        assert_eq!(count, 1, "duplicate path was not deduped: {:?}", aux);
+    }
+
+    /// Path-normalization byte-identity invariant: the path emitted by
+    /// `collect_aux_files` for a deleted role file must byte-match the
+    /// path the differ's `build_diff_set` produces for the same deleted
+    /// file. If this drifts, the deletion case silently breaks in
+    /// production.
+    ///
+    /// **Treat any failure here as a release blocker.** The fix is
+    /// almost always to add a `lexically_normalize` / `canonicalize_or_join_against_root`
+    /// helper applied uniformly on both sides.
+    #[test]
+    fn composer_aux_path_byte_matches_diff_set_path_for_deleted_role_file() {
+        let tmp = TempDir::new().unwrap();
+        let repo_root = tmp.path();
+        mkdir(repo_root, "infrastructure/tc/foo");
+        mkdir(repo_root, "topologies/foo/myfn");
+
+        // Mirror what the composer produces for an `infra_dir`: an
+        // absolute, canonical path under the repo root.
+        let infra_dir = repo_root
+            .canonicalize()
+            .unwrap()
+            .join("infrastructure/tc/foo")
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        let composer_path: String = collect_aux_files(
+            &infra_dir,
+            &fake_fspec("myfn"),
+            Some(&fake_rspec_no_overrides()),
+            &fake_role_no_path(),
+        )
+        .into_iter()
+        .find(|p| p.ends_with("roles/myfn.json"))
+        .expect("conventional role path must always be emitted");
+
+        // Mirror `build_diff_set`: canonicalize the repo root, join
+        // the rel path, fall back to the logical join when the file
+        // doesn't exist (deletion case).
+        let rel = "infrastructure/tc/foo/roles/myfn.json";
+        let canonical_root = repo_root.canonicalize().unwrap();
+        let joined = canonical_root.join(rel);
+        let diff_path: PathBuf = joined.canonicalize().unwrap_or(joined);
+
+        assert_eq!(
+            PathBuf::from(&composer_path),
+            diff_path,
+            "composer aux path and differ diff-set path MUST be \
+             byte-identical for the deletion case to fire"
+        );
+    }
+
+    /// Same byte-identity invariant as above, but for the conventional
+    /// vars file.
+    #[test]
+    fn composer_aux_path_byte_matches_diff_set_path_for_deleted_vars_file() {
+        let tmp = TempDir::new().unwrap();
+        let repo_root = tmp.path();
+        mkdir(repo_root, "infrastructure/tc/foo");
+
+        let infra_dir = repo_root
+            .canonicalize()
+            .unwrap()
+            .join("infrastructure/tc/foo")
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        let composer_path: String = collect_aux_files(
+            &infra_dir,
+            &fake_fspec("myfn"),
+            Some(&fake_rspec_no_overrides()),
+            &fake_role_no_path(),
+        )
+        .into_iter()
+        .find(|p| p.ends_with("vars/myfn.json"))
+        .expect("conventional vars path must always be emitted");
+
+        let rel = "infrastructure/tc/foo/vars/myfn.json";
+        let canonical_root = repo_root.canonicalize().unwrap();
+        let joined = canonical_root.join(rel);
+        let diff_path: PathBuf = joined.canonicalize().unwrap_or(joined);
+
+        assert_eq!(
+            PathBuf::from(&composer_path),
+            diff_path,
+            "composer aux vars path must byte-match differ diff-set path"
+        );
     }
 }

--- a/lib/composer/src/aws/transducer.rs
+++ b/lib/composer/src/aws/transducer.rs
@@ -199,7 +199,6 @@ fn make_function(namespace: &str, name: &str, fqn: &str) -> Function {
         fs: None,
         infra_spec: HashMap::new(),
         cluster: String::from(""),
-        aux_files: vec![],
     };
 
     Function {
@@ -217,6 +216,7 @@ fn make_function(namespace: &str, name: &str, fqn: &str) -> Function {
         targets: vec![],
         test: HashMap::new(),
         shared: false,
+        aux_files: vec![],
     }
 }
 

--- a/lib/composer/src/aws/transducer.rs
+++ b/lib/composer/src/aws/transducer.rs
@@ -199,6 +199,7 @@ fn make_function(namespace: &str, name: &str, fqn: &str) -> Function {
         fs: None,
         infra_spec: HashMap::new(),
         cluster: String::from(""),
+        aux_files: vec![],
     };
 
     Function {

--- a/lib/composer/src/topology.rs
+++ b/lib/composer/src/topology.rs
@@ -72,6 +72,15 @@ pub struct Topology {
     pub events: HashMap<String, Event>,
     pub routes: HashMap<String, Route>,
     pub functions: HashMap<String, Function>,
+    /// Full set of this topology's own functions, populated by the
+    /// composer and **never replaced by the resolver**. The resolver
+    /// shrinks `functions` to the modified subset (for code uploads),
+    /// but role/policy reconciliation needs to operate over every
+    /// function so that adding/changing a per-function role JSON
+    /// re-attaches the new role to the lambda even when its code
+    /// hasn't changed.
+    #[serde(default)]
+    pub all_functions: HashMap<String, Function>,
     pub mutations: HashMap<String, Mutation>,
     pub schedules: HashMap<String, Schedule>,
     pub queues: HashMap<String, Queue>,
@@ -765,6 +774,7 @@ fn make(
         events: events,
         routes: routes,
         tests: make_test(spec.tests.clone(), &functions),
+        all_functions: functions.clone(),
         functions: functions,
         schedules: schedule::make_all(&namespace, &infra_dir),
         queues: queues,
@@ -817,6 +827,7 @@ fn make_standalone(dir: &str) -> Topology {
         pools: HashMap::new(),
         roles: make_roles(&functions, &0, &0, &0, &None),
         base_roles: make_base_roles(),
+        all_functions: functions.clone(),
         functions: functions,
         nodes: HashMap::new(),
         mutations: HashMap::new(),

--- a/lib/deployer/src/aws/function.rs
+++ b/lib/deployer/src/aws/function.rs
@@ -224,6 +224,48 @@ async fn update_roles(auth: &Auth, funcs: &HashMap<String, Function>) {
     role::create_or_update(auth, &roles, &HashMap::new()).await;
 }
 
+/// Reconcile the IAM role attached to each lambda with what the
+/// topology declares. Runs over the *full* function list (not the
+/// `find_modified` subset) so a role JSON added or changed under
+/// `infrastructure/.../roles/<fn>.json` is re-attached to its lambda
+/// even when the function's code closure is otherwise unchanged.
+///
+/// Idempotent: `lambda::update_role` reads the current role first and
+/// short-circuits when it already matches, so this sweeps cheaply over
+/// a large topology (one `GetFunctionConfiguration` per function, plus
+/// one `UpdateFunctionConfiguration` per drift).
+pub async fn sync_roles(auth: &Auth, funcs: &HashMap<String, Function>) {
+    if funcs.is_empty() {
+        return;
+    }
+    let client = lambda::make_client(auth).await;
+    let mut tasks = vec![];
+    for (_, f) in funcs.clone() {
+        if !matches!(f.runtime.provider, Provider::Lambda) {
+            continue;
+        }
+        let c = client.clone();
+        let fqn = f.fqn.clone();
+        let role_arn = f.runtime.role.arn.clone();
+        let display = f.name.clone();
+        let h = tokio::spawn(async move {
+            match lambda::update_role(&c, &fqn, &role_arn).await {
+                Ok(true) => println!(
+                    "Re-attaching role {} to {}",
+                    u::split_last(&role_arn, "/"),
+                    &display
+                ),
+                Ok(false) => (),
+                Err(e) => println!("Failed to attach role for {}: {:?}", &display, e),
+            }
+        });
+        tasks.push(h);
+    }
+    for task in tasks {
+        let _ = task.await;
+    }
+}
+
 async fn update_concurrency(auth: &Auth, funcs: &HashMap<String, Function>) {
     for (_, f) in funcs {
         let function = make_lambda(auth, f.clone(), &HashMap::new()).await;

--- a/lib/deployer/src/lib.rs
+++ b/lib/deployer/src/lib.rs
@@ -38,6 +38,7 @@ pub async fn create(auth: &Auth, topology: &Topology, sync: bool) {
         version,
         sandbox,
         functions,
+        all_functions,
         routes,
         events,
         queues,
@@ -69,6 +70,14 @@ pub async fn create(auth: &Auth, topology: &Topology, sync: bool) {
 
     role::create_or_update(auth, roles, tags).await;
     function::create(auth, functions, &tags, is_sync).await;
+    // After roles are reconciled in IAM and modified functions are
+    // (re)deployed, sweep every lambda the topology declares and make
+    // sure its `Role` attribute matches `f.runtime.role.arn`. This is
+    // what re-attaches a freshly-created override role onto an existing
+    // lambda whose code didn't change in this deploy — without this
+    // step IAM ends up with the new role but the lambda keeps pointing
+    // at `tc-base-function-...`.
+    function::sync_roles(auth, all_functions).await;
     channel::create(&auth, channels).await;
     mutation::create(&auth, mutations, &tags).await;
     queue::create(&auth, queues).await;
@@ -110,6 +119,7 @@ async fn update_topology(auth: &Auth, topology: &Topology) {
         namespace,
         version,
         functions,
+        all_functions,
         flow,
         mutations,
         channels,
@@ -135,6 +145,7 @@ async fn update_topology(auth: &Auth, topology: &Topology) {
 
     role::create_or_update(&auth, roles, tags).await;
     function::update_code(&auth, functions, &tags).await;
+    function::sync_roles(&auth, all_functions).await;
     mutation::create(&auth, mutations, &tags).await;
     channel::create(&auth, channels).await;
     event::create(&auth, events, &tags).await;

--- a/lib/differ/src/deps.rs
+++ b/lib/differ/src/deps.rs
@@ -82,6 +82,42 @@ impl Analyzer {
         &self.repo_root
     }
 
+    /// Compute the closure of `fn_dir`, then widen it with explicit
+    /// per-function aux file paths (role JSONs, vars JSONs, etc. — files
+    /// outside the source-code closure whose contents flow into the
+    /// deployed configuration).
+    ///
+    /// Each aux path is canonicalized; if it doesn't resolve on disk
+    /// (deleted between tags, or a conventional path that was never
+    /// created), we keep the logical path so a `DiffSet` entry produced
+    /// by the same `repo_root.join(rel)` fallback still byte-matches and
+    /// the function is correctly flagged. Aux paths that resolve outside
+    /// `repo_root` are dropped — a defense-in-depth measure since the
+    /// composer shouldn't produce them.
+    ///
+    /// **Why a wrapper instead of a parameter on `closure()`.**
+    /// `closure()` populates the per-dir `Refs` cache keyed by directory.
+    /// Aux paths are per-function, not per-dir, so threading them through
+    /// `closure()` would either lose caching or require a separate cache
+    /// layer. Composing `closure(fn_dir) + per-function aux insert`
+    /// keeps the dir-level cache intact.
+    pub fn closure_with_aux(&self, fn_dir: &Path, aux: &[PathBuf]) -> Closure {
+        let mut c = self.closure(fn_dir);
+        for p in aux {
+            match p.canonicalize() {
+                Ok(canon) => {
+                    if canon.starts_with(&self.repo_root) {
+                        c.files.insert(canon);
+                    }
+                }
+                Err(_) => {
+                    c.files.insert(p.clone());
+                }
+            }
+        }
+        c
+    }
+
     /// Compute the closure of `fn_dir`. If the dir doesn't exist or is
     /// outside the repo, returns an empty closure.
     pub fn closure(&self, fn_dir: &Path) -> Closure {
@@ -542,5 +578,119 @@ mod tests {
         // analyzer's cache should show exactly those entries.
         let refs = analyzer.refs.borrow();
         assert_eq!(refs.len(), 3, "cache contents: {:?}", refs.keys());
+    }
+
+    #[test]
+    fn aux_picks_up_role_file_outside_fn_dir() {
+        // A function's role JSON lives in the infrastructure tree, not
+        // under the function's source dir. closure_with_aux must include
+        // the canonical role path so role-only edits flag the function.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkfile(root, "topologies/foo/myfn/handler.py", "def handler(): pass\n");
+        mkfile(root, "infrastructure/tc/foo/roles/myfn.json", "{}");
+
+        let analyzer = Analyzer::new(root).unwrap();
+        let aux = vec![root.join("infrastructure/tc/foo/roles/myfn.json")];
+        let c = analyzer.closure_with_aux(&root.join("topologies/foo/myfn"), &aux);
+
+        let canonical = root
+            .join("infrastructure/tc/foo/roles/myfn.json")
+            .canonicalize()
+            .unwrap();
+        assert!(c.contains(&canonical));
+    }
+
+    #[test]
+    fn aux_handles_deleted_file_path() {
+        // Conventional aux paths are always emitted by the composer,
+        // even when the file doesn't exist on disk (e.g. deleted between
+        // tags). closure_with_aux must keep the logical path so a
+        // DiffSet entry for the deletion (also a logical join) matches.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkfile(root, "topologies/foo/myfn/handler.py", "");
+
+        let analyzer = Analyzer::new(root).unwrap();
+        let logical = root.join("infrastructure/tc/foo/roles/myfn.json");
+        assert!(!logical.exists(), "test setup: file must NOT exist");
+
+        let c = analyzer.closure_with_aux(
+            &root.join("topologies/foo/myfn"),
+            &[logical.clone()],
+        );
+
+        assert!(
+            c.files.contains(&logical),
+            "logical (non-canonical) path must be retained for deletion case; \
+             closure files = {:?}",
+            c.files
+        );
+    }
+
+    #[test]
+    fn aux_drops_paths_outside_repo() {
+        // A real-on-disk aux path that resolves outside the repo must be
+        // silently dropped. Defense in depth — composer shouldn't produce
+        // these, but if it does we don't want false matches against an
+        // unrelated tree.
+        let outer = TempDir::new().unwrap();
+        let repo = TempDir::new().unwrap();
+        let root = repo.path();
+        mkfile(root, "topologies/foo/myfn/handler.py", "");
+        mkfile(outer.path(), "stray/role.json", "{}");
+
+        let analyzer = Analyzer::new(root).unwrap();
+        let outside = outer.path().join("stray/role.json");
+        let c = analyzer.closure_with_aux(
+            &root.join("topologies/foo/myfn"),
+            &[outside.clone()],
+        );
+
+        let canonical = outside.canonicalize().unwrap();
+        assert!(!c.contains(&canonical), "outside-repo aux path leaked in");
+    }
+
+    #[test]
+    fn aux_canonicalizes_symlinks() {
+        // If the aux path itself is a symlink, the canonical target is
+        // what ends up in the closure — and it's also what the diff side
+        // produces from a `repo_root.join(rel).canonicalize()`. Match.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkfile(root, "topologies/foo/myfn/handler.py", "");
+        mkfile(root, "real/role.json", "{}");
+        symlink(root.join("real/role.json"), root.join("link.json")).unwrap();
+
+        let analyzer = Analyzer::new(root).unwrap();
+        let c = analyzer.closure_with_aux(
+            &root.join("topologies/foo/myfn"),
+            &[root.join("link.json")],
+        );
+
+        let canonical_real = root.join("real/role.json").canonicalize().unwrap();
+        assert!(c.contains(&canonical_real));
+    }
+
+    #[test]
+    fn aux_does_not_double_count_paths_in_source_closure() {
+        // A path that's already covered by a closure root (because it
+        // sits under f.dir) and is also explicitly listed as aux must
+        // not produce inconsistent results. `Closure::contains` should
+        // still return true for that path; no duplicate-flagging hazard.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkfile(root, "topologies/foo/myfn/handler.py", "");
+        mkfile(root, "topologies/foo/myfn/role.json", "{}");
+
+        let analyzer = Analyzer::new(root).unwrap();
+        let aux_path = root.join("topologies/foo/myfn/role.json");
+        let c = analyzer.closure_with_aux(
+            &root.join("topologies/foo/myfn"),
+            &[aux_path.clone()],
+        );
+
+        let canonical = aux_path.canonicalize().unwrap();
+        assert!(c.contains(&canonical));
     }
 }

--- a/lib/differ/src/lib.rs
+++ b/lib/differ/src/lib.rs
@@ -366,15 +366,14 @@ fn diff_fns_with(
     for (name, f) in &topology.functions {
         // Aux files (role JSONs, vars JSONs, inherited parent role)
         // live outside f.dir and the source-code closure walker can't
-        // reach them. The composer enumerates them on `Runtime` so the
-        // differ can widen the per-function closure here. A change to
-        // any of these files marks the function dirty even when no
+        // reach them. The composer enumerates them on `Function` so
+        // the differ can widen the per-function closure here. A change
+        // to any of these files marks the function dirty even when no
         // source code changed; the existing deploy path
         // (`lambda::create_or_update`) then writes the full config —
         // role attachment, env block, memory, timeout — using the
         // freshly composed Runtime values.
         let aux: Vec<PathBuf> = f
-            .runtime
             .aux_files
             .iter()
             .map(PathBuf::from)
@@ -558,8 +557,7 @@ mod tests {
                                 "policy_arn": ""
                             }},
                             "infra_spec": {{}},
-                            "cluster": "",
-                            "aux_files": {aux_json}
+                            "cluster": ""
                         }},
                         "build": {{
                             "dir": "{fn_dir}",
@@ -574,7 +572,8 @@ mod tests {
                             "environment": {{}}
                         }},
                         "test": {{}},
-                        "targets": []
+                        "targets": [],
+                        "aux_files": {aux_json}
                     }}
                 }},
                 "all_functions": {{}},

--- a/lib/differ/src/lib.rs
+++ b/lib/differ/src/lib.rs
@@ -149,16 +149,15 @@ pub fn find_between_versions(namespace: &str, from: &str, to: &str) -> Vec<Strin
     find_between_versions_in(namespace, from, to, &u::pwd())
 }
 
-fn files_modified_in_branch() -> Vec<String> {
-    let dir = u::pwd();
-    let branch = u::sh("git rev-parse --abbrev-ref HEAD", &dir);
+fn files_modified_in_branch_in(dir: &str) -> Vec<String> {
+    let branch = u::sh("git rev-parse --abbrev-ref HEAD", dir);
     if branch == "HEAD" {
         return vec![];
     }
     let default = {
         let raw = u::sh(
             "git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'",
-            &dir,
+            dir,
         );
         if raw.is_empty() {
             "main".to_string()
@@ -171,7 +170,7 @@ fn files_modified_in_branch() -> Vec<String> {
     }
     let out = u::sh(
         &format!("git diff --name-only {}...{}", &default, &branch),
-        &dir,
+        dir,
     );
     u::split_lines(&out)
         .iter()
@@ -180,9 +179,27 @@ fn files_modified_in_branch() -> Vec<String> {
         .collect()
 }
 
-fn files_modified_uncommitted() -> Vec<String> {
-    let dir = u::pwd();
-    let out = u::sh("git ls-files -m", &dir);
+/// Tracked-and-modified files across the whole repo. Run from the repo
+/// root so changes outside the current dir — most notably role JSONs
+/// under `infrastructure/tc/...` — are visible regardless of where `tc`
+/// was invoked.
+fn files_modified_uncommitted_in(dir: &str) -> Vec<String> {
+    let out = u::sh("git ls-files -m", dir);
+    u::split_lines(&out)
+        .iter()
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Untracked files (gitignore-respecting). Included in the local diff
+/// set so brand-new files — e.g. a freshly-added role JSON under
+/// `infrastructure/tc/.../roles/{fn}.json` — are visible to the closure
+/// intersection check before they're committed. `--exclude-standard`
+/// keeps gitignored build artifacts (`lambda.zip`, `target/`, etc.) out.
+/// Run from the repo root so paths outside cwd are also reported.
+fn files_untracked_in(dir: &str) -> Vec<String> {
+    let out = u::sh("git ls-files --others --exclude-standard", dir);
     u::split_lines(&out)
         .iter()
         .map(|s| s.to_string())
@@ -193,16 +210,38 @@ fn files_modified_uncommitted() -> Vec<String> {
 /// Build a canonicalized diff set. Paths that don't resolve on disk are
 /// kept as logical joins (they still match starts_with for the deleted-
 /// file case).
+///
+/// `include_local` controls whether the working-tree's modified,
+/// branch-vs-default, and untracked files are folded into the diff in
+/// addition to the strict `from..to` git diff.
+///
+/// - **Deploy time** (`diff_fns`) → `true`. The deploy is going from
+///   the snapshotter-recorded version to the current local code on
+///   disk; uncommitted local edits are part of "current local code" and
+///   the deploy must see them.
+/// - **CLI inspection** (`diff`, called from `tc diff --between A..B`)
+///   → `false`. Both endpoints are explicit committed tags, so the
+///   working-tree state is irrelevant. Including it produces noisy
+///   false positives in checkouts with lots of untracked files (test
+///   payloads, scratch docs, etc.) that happen to live under a
+///   function's source dir.
 fn build_diff_set(
     namespace: &str,
     from: &str,
     to: &str,
     repo_root: &Path,
+    include_local: bool,
 ) -> DiffSet {
-    let mut rels: Vec<String> = find_between_versions(namespace, from, to);
-    if std::env::var("CI").is_err() {
-        rels.extend(files_modified_uncommitted());
-        rels.extend(files_modified_in_branch());
+    let dir = repo_root.to_str().unwrap_or_else(|| {
+        // Should never fire — `repo_root` is canonicalized, valid UTF-8
+        // on every platform we run on. Belt-and-suspenders fallback.
+        ""
+    });
+    let mut rels: Vec<String> = find_between_versions_in(namespace, from, to, dir);
+    if include_local && std::env::var("CI").is_err() {
+        rels.extend(files_modified_uncommitted_in(dir));
+        rels.extend(files_modified_in_branch_in(dir));
+        rels.extend(files_untracked_in(dir));
     }
     rels.sort();
     rels.dedup();
@@ -291,7 +330,10 @@ pub fn diff_fns(
     }
 
     let repo_root = repo_root_canonical();
-    let diff = build_diff_set(namespace, from, to, &repo_root);
+    // Deploy-time path: include local working-tree state because the
+    // deploy is going from the recorded version to current local code
+    // and uncommitted edits are part of what's about to be shipped.
+    let diff = build_diff_set(namespace, from, to, &repo_root, true);
     if diff.is_empty() {
         tracing::debug!("empty diff for {} {}..{}", namespace, from, to);
         return Ok(HashMap::new());
@@ -322,7 +364,22 @@ fn diff_fns_with(
 ) -> HashMap<String, Function> {
     let mut changed: HashMap<String, Function> = HashMap::new();
     for (name, f) in &topology.functions {
-        let closure = analyzer.closure(&PathBuf::from(&f.dir));
+        // Aux files (role JSONs, vars JSONs, inherited parent role)
+        // live outside f.dir and the source-code closure walker can't
+        // reach them. The composer enumerates them on `Runtime` so the
+        // differ can widen the per-function closure here. A change to
+        // any of these files marks the function dirty even when no
+        // source code changed; the existing deploy path
+        // (`lambda::create_or_update`) then writes the full config —
+        // role attachment, env block, memory, timeout — using the
+        // freshly composed Runtime values.
+        let aux: Vec<PathBuf> = f
+            .runtime
+            .aux_files
+            .iter()
+            .map(PathBuf::from)
+            .collect();
+        let closure = analyzer.closure_with_aux(&PathBuf::from(&f.dir), &aux);
         if diff.intersects(&closure) {
             changed.insert(name.clone(), f.clone());
         }
@@ -367,7 +424,12 @@ pub fn diff(topology: &Topology, from: &str, to: &str) {
         }
     } else if from != to {
         let repo_root = repo_root_canonical();
-        let diff = build_diff_set(&topology.namespace, from, to, &repo_root);
+        // CLI inspection path: strict tag-to-tag diff. Don't fold in
+        // the local working tree — the user is asking "what changed
+        // between these two committed versions" and untracked test
+        // payloads / scratch files in the checkout would otherwise
+        // produce false positives.
+        let diff = build_diff_set(&topology.namespace, from, to, &repo_root, false);
         if !diff.is_empty() {
             if let Some(analyzer) = Analyzer::new(&repo_root) {
                 for t in &topologies {
@@ -399,9 +461,13 @@ mod tests {
     use std::path::Path;
     use tempfile::TempDir;
 
+    // ---- Helpers ----
+
     /// Initialize a fresh git repo at `root` with a single commit and
     /// the given tags. Tags are created with the `tag::v` naming scheme
-    /// used everywhere in this codebase: `{namespace}-{version}`.
+    /// used everywhere in this codebase: `{namespace}-{version}`. Used
+    /// by the `ensure_tag` / `find_between_versions_in` tests where a
+    /// lightweight repo with no working-tree dirt is enough.
     fn git_init_with_tags(root: &Path, namespace: &str, tags: &[&str]) {
         let dir = root.to_str().unwrap();
         u::sh("git init -q", dir);
@@ -416,6 +482,458 @@ mod tests {
             u::sh(&format!("git tag {}-{}", namespace, v), dir);
         }
     }
+
+    fn mkfile(root: &Path, rel: &str, contents: &str) {
+        let p = root.join(rel);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(p, contents).unwrap();
+    }
+
+    fn mkdir(root: &Path, rel: &str) {
+        fs::create_dir_all(root.join(rel)).unwrap();
+    }
+
+    /// Build a minimal `Topology` containing a single function with a
+    /// customizable `dir` and `aux_files`. Constructed via `serde_json`
+    /// rather than by hand because the fixture surface is otherwise
+    /// enormous (Runtime alone has ~20 fields, plus nested
+    /// Role/Policy/Trust/etc.). Tests that depend on a particular field
+    /// should set it explicitly through the JSON template.
+    fn fixture_topology(fn_name: &str, fn_dir: &str, aux_files: &[String]) -> Topology {
+        let aux_json = serde_json::to_string(aux_files).unwrap();
+        let json = format!(
+            r#"{{
+                "namespace": "test",
+                "env": "dev",
+                "fqn": "test",
+                "concurrent": false,
+                "kind": "Function",
+                "infra": "",
+                "dir": "/tmp/tc-test-topology",
+                "sandbox": "test",
+                "hyphenated_names": false,
+                "version": "0.0.0",
+                "nodes": {{}},
+                "events": {{}},
+                "routes": {{}},
+                "functions": {{
+                    "{fn_name}": {{
+                        "name": "{fn_name}",
+                        "actual_name": "{fn_name}",
+                        "namespace": "test",
+                        "dir": "{fn_dir}",
+                        "description": null,
+                        "fqn": "test_{fn_name}",
+                        "arn": "",
+                        "layer_name": null,
+                        "version": "",
+                        "runtime": {{
+                            "lang": "Python310",
+                            "provider": "Lambda",
+                            "handler": "handler.handler",
+                            "package_type": "zip",
+                            "uri": "",
+                            "layers": [],
+                            "tags": {{}},
+                            "environment": {{}},
+                            "memory_size": null,
+                            "cpu": null,
+                            "timeout": null,
+                            "snapstart": false,
+                            "provisioned_concurrency": null,
+                            "reserved_concurrency": null,
+                            "enable_fs": false,
+                            "network": null,
+                            "fs": null,
+                            "role": {{
+                                "name": "tc-base-function-test",
+                                "kind": "Base",
+                                "path": "",
+                                "trust": {{"Version": "2012-10-17", "Statement": []}},
+                                "arn": "",
+                                "policy_name": "tc-base-function-test",
+                                "policy": {{"Version": "2012-10-17", "Statement": []}},
+                                "policy_arn": ""
+                            }},
+                            "infra_spec": {{}},
+                            "cluster": "",
+                            "aux_files": {aux_json}
+                        }},
+                        "build": {{
+                            "dir": "{fn_dir}",
+                            "kind": "Code",
+                            "pre": [],
+                            "post": [],
+                            "version": null,
+                            "command": "",
+                            "pack": "",
+                            "shared_context": false,
+                            "skip_dev_deps": false,
+                            "environment": {{}}
+                        }},
+                        "test": {{}},
+                        "targets": []
+                    }}
+                }},
+                "all_functions": {{}},
+                "mutations": {{}},
+                "schedules": {{}},
+                "queues": {{}},
+                "channels": {{}},
+                "pools": {{}},
+                "pages": {{}},
+                "tags": {{}},
+                "flow": null,
+                "config": {{
+                    "aws": {{
+                        "lambda": {{
+                            "layers_profile": null,
+                            "extensions_profile": null,
+                            "role": null
+                        }},
+                        "fmt": {{
+                            "fqn": "default"
+                        }}
+                    }},
+                    "ci": {{
+                        "build": {{
+                            "kind": "code",
+                            "version_image": false
+                        }}
+                    }},
+                    "builder": {{
+                        "kind": "Local",
+                        "cluster": null
+                    }}
+                }},
+                "roles": {{}},
+                "base_roles": {{}},
+                "tests": {{}},
+                "transducer": null,
+                "sequences": {{}}
+            }}"#
+        );
+        serde_json::from_str(&json)
+            .unwrap_or_else(|e| panic!("topology fixture failed to deserialize: {e}; json = {json}"))
+    }
+
+    /// End-to-end through `diff_fns_with`: when a role file outside the
+    /// function's source dir is in the diff, the function is flagged.
+    #[test]
+    fn diff_fns_flags_function_when_only_role_file_changed() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkfile(root, "topologies/foo/myfn/handler.py", "");
+        mkfile(root, "infrastructure/tc/foo/roles/myfn.json", "{\"old\": true}");
+
+        let fn_dir = root.join("topologies/foo/myfn").to_str().unwrap().to_string();
+        let role_path = root
+            .join("infrastructure/tc/foo/roles/myfn.json")
+            .to_str()
+            .unwrap()
+            .to_string();
+        let topology = fixture_topology("myfn", &fn_dir, &[role_path.clone()]);
+
+        let analyzer = Analyzer::new(root).unwrap();
+
+        // Simulate `build_diff_set` for a modified file: canonicalize
+        // the changed path. (Modification case — file exists.)
+        let canonical = PathBuf::from(&role_path).canonicalize().unwrap();
+        let diff = DiffSet { files: vec![canonical] };
+
+        let changed = diff_fns_with(&topology, &diff, &analyzer);
+        assert!(
+            changed.contains_key("myfn"),
+            "function must be flagged when only its role file changed; \
+             changed = {:?}",
+            changed.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// End-to-end through `diff_fns_with` for the deletion case: a
+    /// vars file that existed at tag A but not at tag B. The differ
+    /// records the deletion as a logical join of repo_root + rel; the
+    /// composer emits the same logical path in `aux_files` because the
+    /// conventional path is always emitted regardless of on-disk
+    /// existence. Both must match for the function to be flagged.
+    #[test]
+    fn diff_fns_flags_function_when_only_vars_file_deleted() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkfile(root, "topologies/foo/myfn/handler.py", "");
+        mkdir(root, "infrastructure/tc/foo");
+        // NOTE: vars/myfn.json deliberately does NOT exist on disk —
+        // this is the deletion-at-tag-B case.
+
+        let fn_dir = root.join("topologies/foo/myfn").to_str().unwrap().to_string();
+        // The composer would emit the conventional path even though the
+        // file is gone — mirror that here.
+        let canonical_root = root.canonicalize().unwrap();
+        let logical_vars_path = canonical_root
+            .join("infrastructure/tc/foo/vars/myfn.json")
+            .to_str()
+            .unwrap()
+            .to_string();
+        let topology =
+            fixture_topology("myfn", &fn_dir, &[logical_vars_path.clone()]);
+
+        let analyzer = Analyzer::new(root).unwrap();
+
+        // Mirror `build_diff_set`'s deletion fallback: canonicalize
+        // fails, so we keep the logical join.
+        let rel = "infrastructure/tc/foo/vars/myfn.json";
+        let joined = canonical_root.join(rel);
+        let diff_path = joined.canonicalize().unwrap_or(joined);
+        let diff = DiffSet { files: vec![diff_path] };
+
+        let changed = diff_fns_with(&topology, &diff, &analyzer);
+        assert!(
+            changed.contains_key("myfn"),
+            "function must be flagged when its vars file was deleted; \
+             changed = {:?}",
+            changed.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// Sanity check: an empty diff (nothing changed) does not flag the
+    /// function even though it has aux_files declared.
+    #[test]
+    fn diff_fns_does_not_flag_when_diff_is_empty() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        mkfile(root, "topologies/foo/myfn/handler.py", "");
+        mkfile(root, "infrastructure/tc/foo/roles/myfn.json", "{}");
+
+        let fn_dir = root.join("topologies/foo/myfn").to_str().unwrap().to_string();
+        let role_path = root
+            .join("infrastructure/tc/foo/roles/myfn.json")
+            .to_str()
+            .unwrap()
+            .to_string();
+        let topology = fixture_topology("myfn", &fn_dir, &[role_path]);
+
+        let analyzer = Analyzer::new(root).unwrap();
+        let diff = DiffSet { files: vec![] };
+
+        let changed = diff_fns_with(&topology, &diff, &analyzer);
+        assert!(
+            changed.is_empty(),
+            "no diff means no function should be flagged; changed = {:?}",
+            changed.keys().collect::<Vec<_>>()
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // `include_local` gating regression tests
+    //
+    // These tests exercise a regression that shipped briefly: the CLI
+    // helper `tc diff --between A..B` was pulling in the local working
+    // tree (modified, branch-vs-default, untracked) on top of the
+    // strict tag-to-tag git diff. That's correct for the deploy path
+    // (`diff_fns`, where local edits are part of what's about to ship),
+    // but wrong for inspection — checkouts with lots of untracked test
+    // payloads / scratch docs under a function's source dir produced
+    // false positives unrelated to anything that actually changed
+    // between the two tags.
+    //
+    // The fix threaded an `include_local: bool` through `build_diff_set`
+    // and the helpers it calls. These tests pin that contract: they
+    // build a real git repo in a TempDir and verify the gate's effect
+    // end-to-end.
+    // -------------------------------------------------------------------
+
+    /// Run `git` in `dir` via raw `Command` (NOT `u::sh`) so we don't
+    /// depend on the parent test process's PWD or `u::root()`'s
+    /// OnceLock cache. Returns the trimmed stdout. Panics on non-zero
+    /// exit so misconfigured fixtures fail loudly.
+    fn git(dir: &Path, args: &[&str]) -> String {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            // Provide author identity inline — the test environment
+            // may not have a global git config.
+            .env("GIT_AUTHOR_NAME", "tc-test")
+            .env("GIT_AUTHOR_EMAIL", "tc-test@localhost")
+            .env("GIT_COMMITTER_NAME", "tc-test")
+            .env("GIT_COMMITTER_EMAIL", "tc-test@localhost")
+            .output()
+            .unwrap_or_else(|e| panic!("git {:?} in {:?} failed to spawn: {e}", args, dir));
+        if !out.status.success() {
+            panic!(
+                "git {:?} in {:?} failed: stdout={} stderr={}",
+                args,
+                dir,
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    /// Synthetic git history with three tags:
+    ///
+    /// - `0.0.1` (A): commits `handler.py` + `roles/myfn.json`.
+    /// - `0.0.2` (B): modifies `roles/myfn.json`.
+    /// - `0.0.3` (C): adds `otherfn/handler.py`.
+    ///
+    /// After the last tag, the working tree is dirtied with:
+    /// - an untracked `topologies/foo/myfn/scratch.json` (the kind of
+    ///   stray test payload that the bug was flagging).
+    /// - an uncommitted modification to `otherfn/handler.py`.
+    ///
+    /// The strict tag-to-tag diff between any pair of these tags
+    /// should never surface the post-tag dirt.
+    fn synthetic_repo(namespace: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        git(dir, &["init", "--quiet", "--initial-branch=main"]);
+        git(dir, &["config", "commit.gpgsign", "false"]);
+        // Disable any global hooks that might inject content.
+        git(dir, &["config", "core.hooksPath", "/dev/null"]);
+
+        // Tag A.
+        mkfile(dir, "topologies/foo/myfn/handler.py", "v1\n");
+        mkfile(dir, "infrastructure/tc/foo/roles/myfn.json", "{\"v\": 1}");
+        git(dir, &["add", "."]);
+        git(dir, &["commit", "--quiet", "-m", "v1"]);
+        git(dir, &["tag", &format!("{}-0.0.1", namespace)]);
+
+        // Tag B: change one tracked file.
+        fs::write(
+            dir.join("infrastructure/tc/foo/roles/myfn.json"),
+            "{\"v\": 2}",
+        )
+        .unwrap();
+        git(dir, &["add", "."]);
+        git(dir, &["commit", "--quiet", "-m", "v2"]);
+        git(dir, &["tag", &format!("{}-0.0.2", namespace)]);
+
+        // Tag C: add a new function dir + handler.
+        mkfile(dir, "topologies/foo/otherfn/handler.py", "v1\n");
+        git(dir, &["add", "."]);
+        git(dir, &["commit", "--quiet", "-m", "add otherfn"]);
+        git(dir, &["tag", &format!("{}-0.0.3", namespace)]);
+
+        // ---- Working-tree noise (deliberately AFTER all tags + adds) ----
+        // Stray untracked file under a function's source dir. This is
+        // the kind of file (test payload, scratch doc, etc.) that the
+        // bug was incorrectly flagging in `tc diff --between A..B`.
+        mkfile(dir, "topologies/foo/myfn/scratch.json", "untracked");
+        // Uncommitted modification to a tracked file. Also must be
+        // invisible to a strict tag-to-tag inspection.
+        fs::write(dir.join("topologies/foo/otherfn/handler.py"), "v1-edited\n").unwrap();
+
+        tmp
+    }
+
+    /// **Regression test.** When `include_local=false`, the diff set
+    /// must contain only what `git diff A..B` reports — never the
+    /// working tree's modifications, branch-vs-default diff, or
+    /// untracked files.
+    ///
+    /// Reproduces the bug behind `tc diff --between 0.0.333..0.0.334`
+    /// reporting six functions when only two had genuinely changed
+    /// (the four extras were dirs containing untracked test payloads).
+    #[test]
+    fn build_diff_set_excludes_local_state_when_include_local_is_false() {
+        let tmp = synthetic_repo("ns");
+        let dir = tmp.path();
+
+        // Sanity: the working tree contains the noise we expect.
+        assert!(
+            dir.join("topologies/foo/myfn/scratch.json").exists(),
+            "fixture: untracked file must exist"
+        );
+
+        let diff = build_diff_set("ns", "0.0.2", "0.0.3", dir, false);
+        let paths: Vec<String> = diff
+            .files
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+
+        // 0.0.2 -> 0.0.3 introduced topologies/foo/otherfn/handler.py.
+        assert!(
+            paths.iter().any(|p| p.ends_with("topologies/foo/otherfn/handler.py")),
+            "tag-to-tag diff must surface the committed change; got {:?}",
+            paths
+        );
+        // The untracked scratch file must NOT appear.
+        assert!(
+            !paths.iter().any(|p| p.ends_with("topologies/foo/myfn/scratch.json")),
+            "untracked working-tree file leaked into a strict tag-to-tag \
+             diff (this is the regression we're guarding against); got {:?}",
+            paths
+        );
+        // The diff between two committed tags should be exactly one
+        // path: the committed addition. No spillover from the
+        // working-tree noise the fixture stages after the tag.
+        assert_eq!(
+            paths.len(),
+            1,
+            "strict tag-to-tag diff should contain exactly the committed \
+             change; got {:?}",
+            paths
+        );
+    }
+
+    /// Counterpart: when `include_local=true` (the deploy-time path),
+    /// the same untracked file IS picked up. This verifies that the
+    /// gating is the only behavioral difference, so the fix doesn't
+    /// silently regress the deploy-time semantics.
+    #[test]
+    fn build_diff_set_includes_local_state_when_include_local_is_true() {
+        // Skip when running under CI=1 — `build_diff_set` short-circuits
+        // local-state collection there for the same reason real CI
+        // runs do (avoid noisy uncommitted state on shared runners).
+        // Setting/unsetting CI globally inside a single test is racy
+        // because env mutation isn't thread-safe across cargo's parallel
+        // test runner; punt cleanly instead.
+        if std::env::var("CI").is_ok() {
+            eprintln!("skipping include_local=true test under CI=1");
+            return;
+        }
+
+        let tmp = synthetic_repo("ns");
+        let dir = tmp.path();
+
+        let diff = build_diff_set("ns", "0.0.2", "0.0.3", dir, true);
+        let paths: Vec<String> = diff
+            .files
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+
+        assert!(
+            paths.iter().any(|p| p.ends_with("topologies/foo/myfn/scratch.json")),
+            "include_local=true must surface untracked working-tree \
+             files (deploy-time semantics); got {:?}",
+            paths
+        );
+    }
+
+    /// Empty `from..to` range: no committed changes, and we still want
+    /// the gate to do the right thing for the inspection path. With
+    /// `include_local=false` and a clean (no-op) tag pair, the diff
+    /// set must be empty regardless of working-tree state.
+    #[test]
+    fn build_diff_set_is_empty_for_same_tag_when_include_local_is_false() {
+        let tmp = synthetic_repo("ns");
+        let dir = tmp.path();
+
+        let diff = build_diff_set("ns", "0.0.2", "0.0.2", dir, false);
+        assert!(
+            diff.files.is_empty(),
+            "from == to with include_local=false must yield empty diff; \
+             got {:?}",
+            diff.files
+        );
+    }
+
+    // ---- ensure_tag / find_between_versions_in (from upstream PR #67) ----
 
     #[test]
     fn ensure_tag_returns_true_for_existing_tag() {

--- a/lib/provider/src/aws/lambda.rs
+++ b/lib/provider/src/aws/lambda.rs
@@ -827,6 +827,52 @@ pub struct Config {
     pub package_type: String,
 }
 
+/// Update only the IAM role on an existing lambda. Idempotent: if the
+/// configured role already matches `role_arn`, the call is skipped so
+/// we don't burn a needless `update_function_configuration` API call.
+/// Returns `Ok(false)` if the function doesn't exist (caller should
+/// rely on the create path to set the role) or already had the right
+/// role; `Ok(true)` if we issued an update.
+pub async fn update_role(client: &Client, name: &str, role_arn: &str) -> Result<bool, Error> {
+    let current = find_config(client, name).await;
+    let needs_update = match current {
+        Some(cfg) => cfg.role != role_arn,
+        None => return Ok(false),
+    };
+    if !needs_update {
+        return Ok(false);
+    }
+    // Wait for any in-flight update to complete before issuing ours —
+    // AWS returns ResourceConflictException otherwise.
+    let mut state = LastUpdateStatus::InProgress;
+    let mut tries = 0;
+    while state == LastUpdateStatus::InProgress && tries < 60 {
+        let r = client
+            .get_function_configuration()
+            .function_name(s!(name))
+            .send()
+            .await;
+        match r {
+            Ok(res) => state = res.last_update_status.unwrap_or(LastUpdateStatus::Successful),
+            Err(_) => break,
+        }
+        if state == LastUpdateStatus::InProgress {
+            sleep(800);
+        }
+        tries += 1;
+    }
+    let res = client
+        .update_function_configuration()
+        .function_name(s!(name))
+        .role(s!(role_arn))
+        .send()
+        .await;
+    match res {
+        Ok(_) => Ok(true),
+        Err(e) => Err(e.into()),
+    }
+}
+
 pub async fn find_config(client: &Client, name: &str) -> Option<Config> {
     let r = client
         .get_function_configuration()


### PR DESCRIPTION
The differ's per-function closure was only walking files under `f.dir`, so changes to a function's role JSON, vars JSON, or inherited parent `roles/function.json` (all of which live in the `infrastructure/tc/...` tree, not the source-code tree) were silently invisible. A Base->Override role transition, a vars file edit, or a deletion would compose correctly into a fresh `Runtime` but never reach the deploy path, leaving the live Lambda pointing at stale config.

Composer now surfaces `aux_files: Vec<String>` on `Runtime` via a new `collect_aux_files` helper, populated by `make_lambda`, `make_fargate`, and `make_default`. The conventional `{infra_dir}/{roles,vars}/{name}.json` paths are emitted unconditionally so deletions still flip the function dirty; overrides and inherited parent role files are emitted when present. The field is `#[serde(default)]` so resolver-cached topologies predating this change continue to deserialize cleanly.

Differ adds `Analyzer::closure_with_aux` that widens the source-code closure with the aux paths (canonicalizing where they exist on disk; keeping logical paths when they don't, so the deletion case byte-matches `build_diff_set`'s same fallback). `diff_fns_with` now threads `f.runtime.aux_files` through it.

Also fixes a separate regression where `tc diff --between A..B` (CLI inspection) was folding the working-tree state into the diff set, polluting the result with every untracked file in the checkout. The deploy-time path (`diff_fns`) still includes local state because uncommitted edits are part of what's about to ship; the inspection path now passes `include_local: false`. Refactored the file-collection helpers to take an explicit `dir` parameter so a focused regression test can pin the gating behavior with a real git repo in a TempDir.

Existing scaffolding kept as defense-in-depth: `Topology.all_functions` is now populated by the composer, and the deployer's `sync_roles` sweeps the full function list to reconcile each Lambda's `Role` attribute via a new idempotent `lambda::update_role`. This catches any aux-file paths the differ misses (e.g. a future config source we haven't taught `collect_aux_files` about yet) without forcing a code redeploy.

Tests: 14 composer + 38 differ, all passing.
- 5 closure-level unit tests for `closure_with_aux`
- 6 composer unit tests for `collect_aux_files`
- 2 byte-identity tests asserting composer's emitted aux path matches the differ's `build_diff_set` path for deleted files (release blocker if these ever drift)
- 3 integration tests through `diff_fns_with` with a synthetic Topology fixture
- 3 regression tests for the `include_local` gate using a real git repo in a TempDir

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes function dirty-detection and deploy behavior by widening closures and adding a full-role reconciliation sweep, which could cause unexpected redeploys/extra AWS API calls if path handling is wrong (especially around canonicalization/deletions).
> 
> **Overview**
> **Function change detection now accounts for non-code config inputs.** The composer records per-function `aux_files` (conventional role/vars JSON paths, explicit overrides, and inherited parent `roles/function.json`), and the differ widens each function’s dependency closure with these paths so edits/additions/deletions under `infrastructure/...` correctly mark the function modified.
> 
> **Deploy now reconciles Lambda roles even when code didn’t change.** Topologies carry `all_functions` (full set, not resolver-pruned), and the deployer runs a new `sync_roles` sweep that uses an idempotent `lambda::update_role` to re-attach the expected IAM role to each Lambda after deploy/update.
> 
> **Fixes noisy CLI diffs.** `build_diff_set` gains an `include_local` gate so `tc diff --between A..B` uses strict tag-to-tag diffs (excluding working-tree modified/untracked files), while deploy-time diffs still include local state. Extensive new unit/regression tests cover aux-path handling, deletion byte-identity, and the `include_local` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2c99ef4967613d395e028a26fb8d092f2749c01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->