### PR TITLE
Set aux_files in fspec

### DIFF
--- a/lib/compiler/src/spec/function.rs
+++ b/lib/compiler/src/spec/function.rs
@@ -411,6 +411,7 @@ pub struct FunctionSpec {
     pub assets: Option<AssetsSpec>,
 
     pub targets: Option<Vec<TargetSpec>>,
+    pub aux_files: Option<Vec<String>>,
 }
 
 fn find_revision(dir: &str) -> String {
@@ -531,6 +532,7 @@ fn load_fspec_file(dir: &str) -> Option<FunctionSpec> {
             test: None,
             tasks: HashMap::new(),
             targets: None,
+            aux_files: None
         })
     }
 }
@@ -558,6 +560,7 @@ impl FunctionSpec {
                 test: None,
                 tasks: HashMap::new(),
                 targets: None,
+                aux_files: None
             },
         }
     }
@@ -600,6 +603,7 @@ impl InlineFunctionSpec {
             test: None,
             tasks: HashMap::new(),
             targets: targets,
+            aux_files: None
         }
     }
 

--- a/lib/composer/src/aws/function.rs
+++ b/lib/composer/src/aws/function.rs
@@ -148,12 +148,16 @@ impl Function {
         };
 
         let runtime = Runtime::new(dir, infra_dir, &namespace, &fspec, &fqn, &config);
-        let aux_files = collect_aux_files(
+        let mut aux_files = collect_aux_files(
             infra_dir,
             &fspec,
             fspec.runtime.as_ref(),
             &runtime.role,
         );
+
+        if let Some(ref afiles) =  fspec.aux_files {
+            aux_files.extend(afiles.clone());
+        }
 
         let targets = Target::make_all(&fspec);
 


### PR DESCRIPTION
fspec.aux_files shadows function.aux_files. The latter is inferred.

The aux_files are then relayed to the differ to detect auxillary file changes both inffered and given.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the set of files considered for function change detection, which can alter deploy/diff behavior (false positives/negatives) if paths are misconfigured.
> 
> **Overview**
> Adds an optional `aux_files` field to `FunctionSpec` so function specs can explicitly declare extra auxiliary file paths.
> 
> During AWS function composition (`Function::new`), the inferred aux file list from `collect_aux_files` is now extended with any `fspec.aux_files`, so the differ can treat changes to both inferred and explicitly declared files as making the function dirty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a779a502da1037fb55b9403151b980c2de297bff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->