### PR TITLE
Make freeze and unfreeze polymorphic

### DIFF
--- a/lib/composer/src/aws/page.rs
+++ b/lib/composer/src/aws/page.rs
@@ -131,7 +131,7 @@ pub struct Page {
     pub skip_deploy: bool,
 }
 
-fn make_functions(kind: &str, fns: Option<Functions>) -> HashMap<String, String> {
+fn make_functions(kind: &str, dir: &str, fns: Option<Functions>) -> HashMap<String, String> {
     let mut xs: HashMap<String, String> = HashMap::new();
     let redirect = format!(
         r#"
@@ -148,7 +148,7 @@ function handler(event) {{
 
     if let Some(f) = fns {
         if let Some(req) = f.request {
-            let path = u::absolutize(&u::pwd(), &req);
+            let path = u::absolutize(dir, &req);
             let js = u::slurp(&path);
             xs.insert("request".to_string(), js);
         } else {
@@ -158,7 +158,7 @@ function handler(event) {{
         }
 
         if let Some(res) = f.response {
-            let path = u::absolutize(&u::pwd(), &res);
+            let path = u::absolutize(dir, &res);
             let js = u::slurp(&path);
             xs.insert("response".to_string(), js);
         }
@@ -245,6 +245,7 @@ fn find_dist(dir: &str, given_dist: Option<String>) -> String {
 }
 
 fn make(
+    tdir: &str,
     name: &str,
     namespace: &str,
     ps: &PageSpec,
@@ -278,7 +279,7 @@ fn make(
     Page {
         fqn: fqn,
         namespace: namespace.to_string(),
-        dir: dir,
+        dir: dir.clone(),
         kind: kind.to_string(),
         dist: dist,
         build: build,
@@ -291,17 +292,17 @@ fn make(
         default_root_object: s!("index.html"),
         domains: find_domains(&ps.domains, infra),
         config_template: ps.config_template.clone(),
-        functions: make_functions(kind, ps.functions.clone()),
+        functions: make_functions(kind, &tdir, ps.functions.clone()),
         skip_deploy: should_skip,
     }
 }
 
-pub fn make_all(spec: &TopologySpec, infra_dir: &str, config: &Config) -> HashMap<String, Page> {
+pub fn make_all(dir: &str, spec: &TopologySpec, infra_dir: &str, config: &Config) -> HashMap<String, Page> {
     let mut h: HashMap<String, Page> = HashMap::new();
     if let Some(pspec) = &spec.pages {
         for (name, ps) in pspec {
             let maybe_infra = Infra::new(infra_dir, &spec.name, &name);
-            let page = make(&name, &spec.name, ps, &maybe_infra, config);
+            let page = make(dir, &name, &spec.name, ps, &maybe_infra, config);
             h.insert(name.to_string(), page);
         }
     }

--- a/lib/composer/src/lib.rs
+++ b/lib/composer/src/lib.rs
@@ -154,6 +154,7 @@ pub fn lookup_versions(dir: &str) -> HashMap<String, String> {
     h
 }
 
+
 pub fn root_namespaces(dir: &str) -> HashMap<String, String> {
     let f = format!("{}/topology.yml", dir);
     let spec = TopologySpec::new(&f);

--- a/lib/composer/src/topology.rs
+++ b/lib/composer/src/topology.rs
@@ -782,7 +782,7 @@ fn make(
         channels: channels,
         pools: make_pools(&spec, &config),
         tags: tag::make(&spec.name, &infra_dir),
-        pages: page::make_all(&spec, &infra_dir, &config),
+        pages: page::make_all(dir, &spec, &infra_dir, &config),
         flow: flow,
         config: Config::new(),
         transducer: maybe_transducer,

--- a/lib/deployer/src/aws/event.rs
+++ b/lib/deployer/src/aws/event.rs
@@ -172,3 +172,15 @@ pub async fn create_dry_run(events: &HashMap<String, Event>) {
         }
     }
 }
+
+pub async fn freeze(_auth: &Auth, _fqn: &str) {
+    println!("Unimplemented")
+}
+
+pub async fn unfreeze(_auth: &Auth, _fqn: &str) {
+    println!("Unimplemented")
+}
+
+pub async fn is_frozen(_auth: &Auth, _fqn: &str) -> bool {
+    false
+}

--- a/lib/deployer/src/aws/function.rs
+++ b/lib/deployer/src/aws/function.rs
@@ -8,6 +8,7 @@ use composer::{
     Transducer,
 };
 use kit as u;
+use kit::s;
 use provider::{
     Auth,
     aws::lambda,
@@ -290,7 +291,7 @@ async fn update_tags(
     let client = lambda::make_client(auth).await;
     for (_, f) in funcs {
         let arn = auth.lambda_arn(&f.fqn);
-        lambda::update_tags(client.clone(), &arn, tags.clone()).await;
+        lambda::update_tags(&client, &arn, tags.clone()).await;
     }
 }
 
@@ -418,4 +419,33 @@ pub async fn create_transducer(
 pub async fn delete_transducer(auth: &Auth, transducer: &Transducer) {
     let function = make_lambda(auth, transducer.function.clone(), &HashMap::new()).await;
     function.clone().delete().await.unwrap();
+}
+
+pub async fn freeze(auth: &Auth, fqn: &str) {
+    let client = lambda::make_client(auth).await;
+    let arn = auth.lambda_arn(fqn);
+    let version = lambda::get_tag(&client, &arn, s!("version")).await;
+    if &version != "0.0.1" && !&version.is_empty() {
+        println!("Freezing function {} ({})", fqn, version);
+        let kv = u::kv("freeze", "true");
+        let _ = lambda::update_tags(&client, &arn, kv).await;
+    }
+}
+
+pub async fn unfreeze(auth: &Auth, fqn: &str) {
+    let client = lambda::make_client(auth).await;
+    let arn = auth.sfn_arn(fqn);
+    let version = lambda::get_tag(&client, &arn, s!("version")).await;
+    if &version != "0.0.1" && !&version.is_empty() {
+        println!("Unfreezing function {} ({})", fqn, version);
+        let kv = u::kv("freeze", "false");
+        let _ = lambda::update_tags(&client, &arn, kv).await;
+    }
+}
+
+pub async fn is_frozen(auth: &Auth, fqn: &str) -> bool {
+    let client = lambda::make_client(auth).await;
+    let arn = auth.lambda_arn(fqn);
+    let v = lambda::get_tag(&client, &arn, s!("freeze")).await;
+    v == "true"
 }

--- a/lib/deployer/src/aws/function.rs
+++ b/lib/deployer/src/aws/function.rs
@@ -434,7 +434,7 @@ pub async fn freeze(auth: &Auth, fqn: &str) {
 
 pub async fn unfreeze(auth: &Auth, fqn: &str) {
     let client = lambda::make_client(auth).await;
-    let arn = auth.sfn_arn(fqn);
+    let arn = auth.lambda_arn(fqn);
     let version = lambda::get_tag(&client, &arn, s!("version")).await;
     if &version != "0.0.1" && !&version.is_empty() {
         println!("Unfreezing function {} ({})", fqn, version);

--- a/lib/deployer/src/aws/mutation.rs
+++ b/lib/deployer/src/aws/mutation.rs
@@ -1,5 +1,6 @@
 use composer::Mutation;
 use kit::*;
+use kit as u;
 use provider::{
     Auth,
     aws::{
@@ -123,5 +124,47 @@ pub async fn create_dry_run(mutations: &HashMap<String, Mutation>) {
         for (name, _) in &mutation.resolvers {
             println!("Creating mutation: {}", name)
         }
+    }
+}
+
+
+
+pub async fn freeze(auth: &Auth, fqn: &str) {
+    let client = appsync::make_client(auth).await;
+    let maybe_api = appsync::find_graphql_api(&client, fqn).await;
+    if let Some(api) = maybe_api {
+        let arn = &auth.graphql_api_arn(&api.id);
+        let version = appsync::get_tag(&client, &arn, s!("version")).await;
+        if &version != "0.0.1" && !&version.is_empty() {
+            println!("Freezing mutation {} ({})", fqn, version);
+            let kv = u::kv("freeze", "true");
+            let _ = appsync::update_tags(&client, &arn, kv).await;
+        }
+    }
+}
+
+pub async fn unfreeze(auth: &Auth, fqn: &str) {
+    let client = appsync::make_client(auth).await;
+    let maybe_api = appsync::find_graphql_api(&client, fqn).await;
+    if let Some(api) = maybe_api {
+        let arn = &auth.graphql_api_arn(&api.id);
+        let version = appsync::get_tag(&client, &arn, s!("version")).await;
+        if &version != "0.0.1" && !&version.is_empty() {
+            println!("Unfreezing mutation {} ({})", fqn, version);
+            let kv = u::kv("freeze", "false");
+            let _ = appsync::update_tags(&client, &arn, kv).await;
+        }
+    }
+}
+
+pub async fn is_frozen(auth: &Auth, fqn: &str) -> bool {
+    let client = appsync::make_client(auth).await;
+    let maybe_api = appsync::find_graphql_api(&client, fqn).await;
+    if let Some(api) = maybe_api {
+        let arn = &auth.graphql_api_arn(&api.id);
+        let v = appsync::get_tag(&client, &arn, s!("freeze")).await;
+        v == "true"
+    } else {
+        false
     }
 }

--- a/lib/deployer/src/aws/route.rs
+++ b/lib/deployer/src/aws/route.rs
@@ -487,3 +487,44 @@ pub async fn config(auth: &Auth, name: &str) -> HashMap<String, String> {
         _ => HashMap::new(),
     }
 }
+
+pub async fn freeze(auth: &Auth, fqn: &str) {
+    let client = gateway::make_client(auth).await;
+    let maybe_api_id = gateway::find_api(&client, fqn).await;
+    if let Some(api_id) = maybe_api_id {
+        let arn = auth.api_gateway_arn(&api_id);
+        let version = gateway::get_tag(&client, &arn, s!("version")).await;
+        if &version != "0.0.1" && !&version.is_empty() {
+            println!("Freezing routes {} ({})", fqn, version);
+            let kv = u::kv("freeze", "true");
+            let _ = gateway::update_tags(&client, &arn, kv).await;
+        }
+    }
+}
+
+pub async fn unfreeze(auth: &Auth, fqn: &str) {
+    let client = gateway::make_client(auth).await;
+    let maybe_api_id = gateway::find_api(&client, fqn).await;
+    if let Some(api_id) = maybe_api_id {
+        let arn = auth.api_gateway_arn(&api_id);
+        let version = gateway::get_tag(&client, &arn, s!("version")).await;
+        if &version != "0.0.1" && !&version.is_empty() {
+            println!("Unfreezing routes {} ({})", fqn, version);
+            let kv = u::kv("freeze", "false");
+            let _ = gateway::update_tags(&client, &arn, kv).await;
+        }
+    }
+}
+
+pub async fn is_frozen(auth: &Auth, fqn: &str) -> bool {
+    let client = gateway::make_client(auth).await;
+    let maybe_api_id = gateway::find_api(&client, fqn).await;
+
+    if let Some(api_id) = maybe_api_id {
+        let arn = auth.api_gateway_arn(&api_id);
+        let v = gateway::get_tag(&client, &arn, s!("freeze")).await;
+        v == "true"
+    } else {
+        false
+    }
+}

--- a/lib/deployer/src/aws/state.rs
+++ b/lib/deployer/src/aws/state.rs
@@ -154,7 +154,7 @@ pub async fn freeze(auth: &Auth, fqn: &str) {
     let arn = auth.sfn_arn(fqn);
     let version = sfn::get_tag(&client, &arn, s!("version")).await;
     if &version != "0.0.1" && !&version.is_empty() {
-        println!("Unfreezing {} ({})", fqn, version);
+        println!("Freezing state {} ({})", fqn, version);
         let kv = u::kv("freeze", "true");
         let _ = sfn::update_tags(&client, &arn, kv).await;
     }
@@ -165,10 +165,17 @@ pub async fn unfreeze(auth: &Auth, fqn: &str) {
     let arn = auth.sfn_arn(fqn);
     let version = sfn::get_tag(&client, &arn, s!("version")).await;
     if &version != "0.0.1" && !&version.is_empty() {
-        println!("Unfreezing {} ({})", fqn, version);
-        let kv = u::kv("freeze", "true");
+        println!("Unfreezing state {} ({})", fqn, version);
+        let kv = u::kv("freeze", "false");
         let _ = sfn::update_tags(&client, &arn, kv).await;
     }
+}
+
+pub async fn is_frozen(auth: &Auth, fqn: &str) -> bool {
+    let client = sfn::make_client(auth).await;
+    let arn = auth.sfn_arn(fqn);
+    let v = sfn::get_tag(&client, &arn, s!("freeze")).await;
+    v == "true"
 }
 
 pub async fn create_dry_run(flow: &Flow) {

--- a/lib/deployer/src/guard.rs
+++ b/lib/deployer/src/guard.rs
@@ -3,16 +3,39 @@ use question::{
     Question,
 };
 
-pub fn is_frozen(env: &str) -> bool {
+use composer::Topology;
+use provider::Auth;
+
+use super::aws::{
+    event,
+    function,
+    mutation,
+    route,
+    state,
+};
+
+use compiler::TopologyKind;
+
+pub async fn is_frozen(auth: &Auth, topology: &Topology) -> bool {
+    let env = &auth.name;
     match std::env::var("TC_FREEZE") {
-        Ok(e) => env == &e,
-        Err(_) => false,
+        Ok(e) => *env == e,
+        Err(_) => {
+            let Topology { fqn, kind, ..} = topology;
+            match kind {
+                TopologyKind::StepFunction => state::is_frozen(auth, fqn).await,
+                TopologyKind::Function => function::is_frozen(auth, fqn).await,
+                TopologyKind::Graphql => mutation::is_frozen(auth, fqn).await,
+                TopologyKind::Routed => route::is_frozen(auth, fqn).await,
+                TopologyKind::Evented => event::is_frozen(auth, fqn).await,
+            }
+        },
     }
 }
 
-pub fn should_abort(env: &str, sandbox: &str) -> bool {
+pub async fn should_abort(auth: &Auth, sandbox: &str, topology: &Topology) -> bool {
     let yes = match std::env::var("CIRCLECI") {
-        Ok(_) => is_frozen(env),
+        Ok(_) => is_frozen(auth, topology).await,
         Err(_) => match std::env::var("TC_FORCE_DEPLOY") {
             Ok(_) => false,
             Err(_) => true,
@@ -21,14 +44,14 @@ pub fn should_abort(env: &str, sandbox: &str) -> bool {
     yes && (sandbox == "stable")
 }
 
-pub fn prevent_stable_updates(env: &str, sandbox: &str) {
-    if is_frozen(env) {
+pub async fn prevent_stable_updates(auth: &Auth, sandbox: &str, topology: &Topology) {
+    if is_frozen(auth, topology).await {
         std::panic::set_hook(Box::new(|_| {
-            println!("QA is frozen. Aborting sandbox update");
+            println!("frozen. Aborting sandbox update");
         }));
-        panic!("QA is frozen. Aborting sandbox update")
+        panic!("{}:{} is frozen. Aborting sandbox update", &auth.name, sandbox)
     }
-    if should_abort(env, sandbox) {
+    if should_abort(auth, sandbox, topology).await {
         std::panic::set_hook(Box::new(|_| {
             println!("Cannot create stable sandbox outside CI");
         }));

--- a/lib/deployer/src/guard.rs
+++ b/lib/deployer/src/guard.rs
@@ -45,12 +45,6 @@ pub async fn should_abort(auth: &Auth, sandbox: &str, topology: &Topology) -> bo
 }
 
 pub async fn prevent_stable_updates(auth: &Auth, sandbox: &str, topology: &Topology) {
-    if is_frozen(auth, topology).await {
-        std::panic::set_hook(Box::new(|_| {
-            println!("frozen. Aborting sandbox update");
-        }));
-        panic!("{}:{} is frozen. Aborting sandbox update", &auth.name, sandbox)
-    }
     if should_abort(auth, sandbox, topology).await {
         std::panic::set_hook(Box::new(|_| {
             println!("Cannot create stable sandbox outside CI");

--- a/lib/deployer/src/guard.rs
+++ b/lib/deployer/src/guard.rs
@@ -17,9 +17,8 @@ use super::aws::{
 use compiler::TopologyKind;
 
 pub async fn is_frozen(auth: &Auth, topology: &Topology) -> bool {
-    let env = &auth.name;
     match std::env::var("TC_FREEZE") {
-        Ok(e) => *env == e,
+        Ok(_) => true,
         Err(_) => {
             let Topology { fqn, kind, ..} = topology;
             match kind {

--- a/lib/deployer/src/lib.rs
+++ b/lib/deployer/src/lib.rs
@@ -15,7 +15,7 @@ use aws::{
     state,
 };
 use colored::Colorize;
-use compiler::Entity;
+use compiler::{Entity, TopologyKind};
 use composer::{
     Function,
     Topology,
@@ -412,13 +412,25 @@ pub async fn try_delete(auth: &Auth, topology: &Topology, maybe_entity: &Option<
 }
 
 pub async fn freeze(auth: &Auth, topology: &Topology) {
-    let Topology { fqn, .. } = topology;
-    state::freeze(auth, fqn).await;
+    let Topology { fqn, kind, ..} = topology;
+    match kind {
+        TopologyKind::StepFunction => state::freeze(auth, fqn).await,
+        TopologyKind::Function => function::freeze(auth, fqn).await,
+        TopologyKind::Graphql => mutation::freeze(auth, fqn).await,
+        TopologyKind::Routed => route::freeze(auth, fqn).await,
+        TopologyKind::Evented => event::freeze(auth, fqn).await,
+    }
 }
 
 pub async fn unfreeze(auth: &Auth, topology: &Topology) {
-    let Topology { fqn, .. } = topology;
-    state::unfreeze(auth, fqn).await;
+    let Topology { fqn, kind, ..} = topology;
+    match kind {
+        TopologyKind::StepFunction => state::unfreeze(auth, fqn).await,
+        TopologyKind::Function => function::unfreeze(auth, fqn).await,
+        TopologyKind::Graphql => mutation::unfreeze(auth, fqn).await,
+        TopologyKind::Routed => route::unfreeze(auth, fqn).await,
+        TopologyKind::Evented => event::unfreeze(auth, fqn).await,
+    }
 }
 
 pub async fn try_list(auth: &Auth, topology: &Topology, maybe_entity: &Option<String>) {

--- a/lib/provider/src/aws/appsync.rs
+++ b/lib/provider/src/aws/appsync.rs
@@ -700,4 +700,13 @@ pub async fn list_api_keys(client: &Client, api_id: &str) -> Vec<String> {
     }
 }
 
+
+pub async fn get_tag(client: &Client, arn: &str, tag: String) -> String {
+    let tags = list_tags(&client, arn).await.unwrap();
+    match tags.get(&tag) {
+        Some(v) => v.to_string(),
+        None => "".to_string(),
+    }
+}
+
 pub type AppsyncClient = Client;

--- a/lib/provider/src/aws/gateway.rs
+++ b/lib/provider/src/aws/gateway.rs
@@ -774,4 +774,29 @@ pub async fn clear_cors(client: &Client, api_id: &str) {
         .unwrap();
 }
 
+pub async fn list_tags(client: &Client, arn: &str) -> Result<HashMap<String, String>, Error> {
+    let res = client
+        .get_tags()
+        .resource_arn(arn.to_string())
+        .send()
+        .await;
+
+    match res {
+        Ok(r) => match r.tags {
+            Some(xs) => Ok(xs),
+            _ => Ok(HashMap::new()),
+        },
+
+        Err(_) => Ok(HashMap::new()),
+    }
+}
+
+pub async fn get_tag(client: &Client, arn: &str, tag: String) -> String {
+    let tags = list_tags(&client, arn).await.unwrap();
+    match tags.get(&tag) {
+        Some(v) => v.to_string(),
+        None => "".to_string(),
+    }
+}
+
 pub type GatewayCors = aws_sdk_apigatewayv2::types::Cors;

--- a/lib/provider/src/aws/lambda.rs
+++ b/lib/provider/src/aws/lambda.rs
@@ -690,7 +690,7 @@ pub async fn add_permission_basic(
     Ok(())
 }
 
-pub async fn update_tags(client: Client, arn: &str, tags: HashMap<String, String>) {
+pub async fn update_tags(client: &Client, arn: &str, tags: HashMap<String, String>) {
     println!("Updating tags {} {:?}", arn, &tags);
     let res = client
         .tag_resource()
@@ -816,6 +816,14 @@ pub async fn list_tags(client: &Client, arn: &str) -> Result<HashMap<String, Str
             }
         }
         Err(_) => Ok(HashMap::new()),
+    }
+}
+
+pub async fn get_tag(client: &Client, arn: &str, tag: String) -> String {
+    let tags = list_tags(&client, arn).await.unwrap();
+    match tags.get(&tag) {
+        Some(v) => v.to_string(),
+        None => "".to_string(),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,7 +358,7 @@ pub async fn create(
             let ct = composer::compose(&dir, recursive);
             let rt = resolver::render(&auth, &sandbox, &ct).await;
             let topology_name = &ct.namespace;
-            if deployer::guard::is_frozen(&auth, &ct).await && notify {
+            if deployer::guard::is_frozen(&auth, &rt).await && notify {
                 let msg = format!(
                     "*{}*::{} is frozen. Aborting deploy: {}",
                     &auth.name, sandbox, topology_name
@@ -453,6 +453,13 @@ pub async fn update(
     let topology = composer::compose(&u::pwd(), recursive);
     let rt = resolver::render(&auth, &sandbox, &topology).await;
 
+    if deployer::guard::is_frozen(&auth, &rt).await {
+        let msg = format!(
+            "*{}*::{} is frozen. Aborting deploy: {}",
+            &auth.name, sandbox, topology.namespace
+        );
+        notifier::notify(&topology.namespace, &msg).await;
+    }
     deployer::guard::prevent_stable_updates(&auth, &sandbox, &rt).await;
 
     let msg = composer::count_of(&topology);
@@ -480,8 +487,16 @@ pub async fn delete(
 
     println!("Composing topology...");
     let topology = composer::compose(&u::pwd(), recursive);
+    let rt = resolver::render(&auth, &sandbox, &topology).await;
 
-    deployer::guard::prevent_stable_updates(&auth, &sandbox, &topology).await;
+    if deployer::guard::is_frozen(&auth, &rt).await {
+        let msg = format!(
+            "*{}*::{} is frozen. Aborting deploy: {}",
+            &auth.name, sandbox, topology.namespace
+        );
+        notifier::notify(&topology.namespace, &msg).await;
+    }
+    deployer::guard::prevent_stable_updates(&auth, &sandbox, &rt).await;
 
     composer::count_of(&topology);
     println!("Resolving topology...");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -757,6 +757,10 @@ pub async fn changelog(between: Option<String>, search: Option<String>, verbose:
 pub async fn prune(auth: &Auth, sandbox: Option<String>, filter: Option<String>, dry_run: bool) {
     match sandbox {
         Some(sbox) => {
+            let dir = u::pwd();
+            let ct = composer::compose(&dir, false);
+            let rt = resolver::render(&auth, &sbox, &ct).await;
+            deployer::guard::prevent_stable_updates(auth, &sbox, &rt).await;
             if dry_run {
                 deployer::list_all(auth, &sbox, "default").await;
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -589,7 +589,7 @@ pub async fn freeze(auth: Auth, sandbox: Option<String>) {
     for (name, topology)  in &topologies {
         deployer::freeze(&auth, &topology).await;
         let msg = format!("*{}*::{} is frozen", &auth.name, &sandbox);
-        //notifier::notify(name, &msg).await;
+        notifier::notify(name, &msg).await;
     }
 }
 
@@ -600,7 +600,7 @@ pub async fn unfreeze(auth: Auth, sandbox: Option<String>) {
     for (name, topology)  in topologies {
         deployer::unfreeze(&auth, &topology).await;
         let msg = format!("*{}*::{} is unfrozen", &auth.name, &sandbox);
-        //notifier::notify(&name, &msg).await;
+        notifier::notify(&name, &msg).await;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use provider::Auth;
 use std::{
     panic,
     time::Instant,
+    collections::HashMap
 };
 use tabled::{
     Style,
@@ -353,17 +354,18 @@ pub async fn create(
             let auth = init(profile, None).await;
             let sandbox = resolver::maybe_sandbox(sandbox);
             let dir = u::pwd();
-            let topology_name = &composer::topology_name(&dir);
-            if deployer::guard::is_frozen(&auth.name) && notify {
+            println!("Composing topology...");
+            let ct = composer::compose(&dir, recursive);
+            let rt = resolver::render(&auth, &sandbox, &ct).await;
+            let topology_name = &ct.namespace;
+            if deployer::guard::is_frozen(&auth, &ct).await && notify {
                 let msg = format!(
                     "*{}*::{} is frozen. Aborting deploy: {}",
                     &auth.name, sandbox, topology_name
                 );
                 notifier::notify(topology_name, &msg).await;
             }
-            deployer::guard::prevent_stable_updates(&auth.name, &sandbox);
-            println!("Composing topology {} ...", topology_name);
-            let ct = composer::compose(&dir, recursive);
+            deployer::guard::prevent_stable_updates(&auth, &sandbox, &rt).await;
             let msg = composer::count_of(&ct);
             println!("C: {}", msg);
 
@@ -447,11 +449,12 @@ pub async fn update(
     interactive: bool,
 ) {
     let sandbox = resolver::maybe_sandbox(sandbox);
-
-    deployer::guard::prevent_stable_updates(&auth.name, &sandbox);
-
     println!("Composing topology...");
     let topology = composer::compose(&u::pwd(), recursive);
+    let rt = resolver::render(&auth, &sandbox, &topology).await;
+
+    deployer::guard::prevent_stable_updates(&auth, &sandbox, &rt).await;
+
     let msg = composer::count_of(&topology);
     println!("{}", msg);
 
@@ -473,11 +476,12 @@ pub async fn delete(
     cache: bool,
 ) {
     let sandbox = resolver::maybe_sandbox(sandbox);
-    deployer::guard::prevent_stable_updates(&auth.name, &sandbox);
-
     let start = Instant::now();
+
     println!("Composing topology...");
     let topology = composer::compose(&u::pwd(), recursive);
+
+    deployer::guard::prevent_stable_updates(&auth, &sandbox, &topology).await;
 
     composer::count_of(&topology);
     println!("Resolving topology...");
@@ -560,22 +564,44 @@ pub async fn route(
     }
 }
 
+async fn find_root_topologies(auth: &Auth, dir: &str, sandbox: &str) -> HashMap<String, Topology> {
+    let is_root = composer::is_root_dir(&dir);
+    let mut h: HashMap<String, Topology> = HashMap::new();
+    if is_root {
+        let topologies = composer::compose_root(&dir, true);
+        for (name, topology) in &topologies {
+            let rt = resolver::render(&auth, &sandbox, &topology).await;
+            h.insert(name.clone(), rt);
+        }
+
+    } else {
+        let topology = composer::compose(&dir, false);
+        let rt = resolver::render(&auth, &sandbox, &topology).await;
+        h.insert(rt.namespace.clone(), rt);
+    }
+    h
+}
+
 pub async fn freeze(auth: Auth, sandbox: Option<String>) {
-    let topology = composer::compose(&u::pwd(), true);
+    let dir = u::pwd();
     let sandbox = resolver::maybe_sandbox(sandbox);
-    let topology = resolver::render(&auth, &sandbox, &topology).await;
-    deployer::freeze(&auth, &topology).await;
-    let msg = format!("*{}*::{} is frozen", &auth.name, sandbox);
-    notifier::notify(&topology.namespace, &msg).await;
+    let topologies = find_root_topologies(&auth, &dir, &sandbox).await;
+    for (name, topology)  in &topologies {
+        deployer::freeze(&auth, &topology).await;
+        let msg = format!("*{}*::{} is frozen", &auth.name, &sandbox);
+        //notifier::notify(name, &msg).await;
+    }
 }
 
 pub async fn unfreeze(auth: Auth, sandbox: Option<String>) {
-    let topology = composer::compose(&u::pwd(), true);
+    let dir = u::pwd();
     let sandbox = resolver::maybe_sandbox(sandbox);
-    let topology = resolver::render(&auth, &sandbox, &topology).await;
-    deployer::unfreeze(&auth, &topology).await;
-    let msg = format!("*{}*::{} is unfrozen", &auth.name, sandbox);
-    notifier::notify(&topology.namespace, &msg).await
+    let topologies = find_root_topologies(&auth, &dir, &sandbox).await;
+    for (name, topology)  in topologies {
+        deployer::unfreeze(&auth, &topology).await;
+        let msg = format!("*{}*::{} is unfrozen", &auth.name, &sandbox);
+        //notifier::notify(&name, &msg).await;
+    }
 }
 
 pub async fn upgrade(version: Option<String>) {
@@ -719,7 +745,6 @@ pub async fn prune(auth: &Auth, sandbox: Option<String>, filter: Option<String>,
             if dry_run {
                 deployer::list_all(auth, &sbox, "default").await;
             } else {
-                deployer::guard::prevent_stable_updates(&auth.name, &sbox);
                 deployer::prune(auth, &sbox, filter).await;
             }
         }


### PR DESCRIPTION
Freeze/unfreeze based on topology kind (kind of root entity). The tags are not updated on all entities but only the root entity for performance reasons.

Events/pages are not typically root entities and typically if there is a root event entity, it is backed by a fn or sfn.

Fixes issue #80 


No LLM used in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes deploy gating and freeze/unfreeze behavior across multiple AWS resource types via tagging, which could block or allow stable deployments if misclassified or tags are missing.
> 
> **Overview**
> **Freeze/unfreeze is now polymorphic by topology kind.** `deployer::freeze`/`unfreeze` and `deployer::guard::is_frozen` now dispatch to Step Functions, Lambda, AppSync (GraphQL), or API Gateway implementations based on `TopologyKind`, instead of assuming a state machine.
> 
> **Freeze state is stored/read via AWS tags.** Adds `freeze`/`unfreeze`/`is_frozen` helpers for Lambda, AppSync, API Gateway, and Step Functions using a `freeze=true|false` tag (guarded by presence of a non-default `version` tag); EventBridge freeze remains stubbed.
> 
> **CLI behavior changes for deploy protection and root operations.** Update/delete flows now render a topology early to check frozen status and prevent stable updates, and `tc freeze/unfreeze` now operates over all composed root topologies when run from a root directory.
> 
> **Minor supporting changes.** Adds `get_tag` helpers in provider clients (Lambda/AppSync/API Gateway) and adjusts Lambda `update_tags` to take `&Client`; page composition now resolves page function JS paths relative to the passed topology dir and threads that dir through `page::make_all`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 382e7ba864eddaf30fdf7271738c3836b75ad22b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->