### PR TITLE
Fix golang lambda build, remove main.go

### DIFF
--- a/lib/builder/src/inline/go.rs
+++ b/lib/builder/src/inline/go.rs
@@ -11,7 +11,7 @@ COPY . .
 ENV GOOS=linux
 ENV CGO_ENABLED=0
 
-RUN go build -tags lambda.norpc -o bootstrap main.go
+RUN go build -tags lambda.norpc -o bootstrap
 "#
     );
     let dockerfile = format!("{}/Dockerfile", dir);


### PR DESCRIPTION
Remove main.go in go build command

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to generated Dockerfile build command in the inline Go builder; no runtime or auth impact.
> 
> **Overview**
> Fixes the inline Go Lambda Docker build by **dropping the hardcoded `main.go` argument** from `go build`, so the image builds the package in `/build` using normal Go module layout instead of requiring a root `main.go`.
> 
> The generated Dockerfile still uses `lambda.norpc` and outputs `bootstrap` for the custom runtime; only the compile target selection changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6963d1e31aacd78af554616ded5aa468fafd9b6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->