### PR TITLE
Fix golang lambda build, remove main.go

### DIFF
--- a/lib/builder/src/inline/go.rs
+++ b/lib/builder/src/inline/go.rs
@@ -11,7 +11,7 @@ COPY . .
 ENV GOOS=linux
 ENV CGO_ENABLED=0
 
-RUN go build -tags lambda.norpc -o bootstrap main.go
+RUN go build -tags lambda.norpc -o bootstrap
 "#
     );
     let dockerfile = format!("{}/Dockerfile", dir);


### PR DESCRIPTION
Remove main.go from go build command

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to generated Docker build instructions for Go lambdas; no runtime auth, data, or security paths affected.
> 
> **Overview**
> Fixes **Go Lambda inline builds** by changing the generated Dockerfile’s build step from `go build ... main.go` to **`go build -tags lambda.norpc -o bootstrap`** with no explicit source file.
> 
> That lets the build use the module’s normal package entry point (e.g. when the handler isn’t in `main.go`), which matches typical `go build` behavior in a copied project root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a05c5e7033b5339fad2129294004f7e0f9d8739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->