### PR TITLE
Sanjeev/fix go lambda build

### DIFF
--- a/lib/builder/src/inline/go.rs
+++ b/lib/builder/src/inline/go.rs
@@ -11,7 +11,7 @@ COPY . .
 ENV GOOS=linux
 ENV CGO_ENABLED=0
 
-RUN go build -tags lambda.norpc -o bootstrap main.go
+RUN go build -tags lambda.norpc -o bootstrap
 "#
     );
     let dockerfile = format!("{}/Dockerfile", dir);

--- a/lib/builder/src/inline/go.rs
+++ b/lib/builder/src/inline/go.rs
@@ -1,17 +1,34 @@
 use kit as u;
 
-pub fn gen_dockerfile(dir: &str) {
+fn deps_str(deps: Vec<String>) -> String {
+    if deps.len() >= 2 {
+        deps.join(" && ")
+    } else if deps.len() == 1 {
+        deps.first().unwrap().to_string()
+    } else {
+        String::from("echo 0")
+    }
+}
+
+pub fn gen_dockerfile(dir: &str, pre: &Vec<String>) {
+    let pre = deps_str(pre.to_vec());
     let f = format!(
         r#"
-FROM public.ecr.aws/sam/build-provided.al2023:1.161
+FROM golang:1.25-alpine AS builder
+
+ENV GOOS=linux
+ENV CGO_ENABLED=0
+ENV GIT_SSH_COMMAND="ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new"
+
+RUN apk add --no-cache git openssh-client
 
 WORKDIR /build
 COPY . .
 
-ENV GOOS=linux
-ENV CGO_ENABLED=0
-
-RUN go build -tags lambda.norpc -o bootstrap
+RUN --mount=type=ssh \
+    {pre} && \
+    go mod download && \
+    go build -tags lambda.norpc -o bootstrap
 "#
     );
     let dockerfile = format!("{}/Dockerfile", dir);

--- a/lib/builder/src/inline/mod.rs
+++ b/lib/builder/src/inline/mod.rs
@@ -35,7 +35,7 @@ fn gen_dockerfile(
             }
         }
         Lang::Rust => rust::gen_dockerfile(dir),
-        Lang::Go => go::gen_dockerfile(dir),
+        Lang::Go => go::gen_dockerfile(dir, pre),
         Lang::Node => node::gen_dockerfile(dir),
         _ => todo!(),
     }
@@ -52,7 +52,7 @@ fn gen_dockerfile_unshared(
         Lang::Python => python::gen_dockerfile_unshared(dir, langr, pre, post),
         Lang::Ruby => ruby::gen_dockerfile_unshared(dir, langr, pre, post),
         Lang::Rust => rust::gen_dockerfile(dir),
-        Lang::Go => go::gen_dockerfile(dir),
+        Lang::Go => go::gen_dockerfile(dir, pre),
         Lang::Node => node::gen_dockerfile(dir),
         _ => todo!(),
     }


### PR DESCRIPTION
Use golang:1.25 alpine image for golang builds
option to input pre build variables for private repo setup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Go Lambda build image and dependency-fetch path; misconfigured SSH or pre steps can break builds, but scope is limited to inline Dockerfile generation.
> 
> **Overview**
> Go inline Lambda builds no longer use the AWS SAM `build-provided.al2023` image; generated Dockerfiles now use **`golang:1.25-alpine`**, install **git** and **openssh-client**, and run **`go mod download`** before **`go build`** with the existing `lambda.norpc` bootstrap output.
> 
> Build steps can inject **pre-build shell commands** from the shared `Build.pre` config (same `deps_str` pattern as Python/Ruby), and the compile `RUN` uses **`--mount=type=ssh`** with **`GIT_SSH_COMMAND`** so private Git module fetch can work when BuildKit SSH is available (shared-context builds already pass `--ssh default`).
> 
> `inline/mod.rs` now passes **`pre`** into **`go::gen_dockerfile`** for both shared and unshared Dockerfile generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 216d459163430f7c8c99600afe42a73468d4fa48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->