### PR TITLE
Fix root domain

### DIFF
--- a/lib/deployer/src/aws/page.rs
+++ b/lib/deployer/src/aws/page.rs
@@ -157,6 +157,7 @@ async fn find_or_create_cert(auth: &Auth, domain: &str, token: &str) -> String {
                 &rec.name,
                 &rec.r#type.as_str(),
                 &rec.value,
+                None
             )
             .await;
         }
@@ -197,7 +198,7 @@ async fn update_bucket_policy(
 async fn update_dns_record(auth: &Auth, domain: &str, dist_id: &str, cname: &str) {
     tracing::debug!("Associating domain {} with {}", domain, &dist_id);
     let rclient = route53::make_client(auth).await;
-    route53::create_record_set(&rclient, domain, domain, "CNAME", cname).await;
+    route53::create_record_set(&rclient, domain, domain, "CNAME", cname, None).await;
 }
 
 async fn build(auth: &Auth, name: &str, page: &Page, config: &HashMap<String, String>) {

--- a/lib/deployer/src/aws/route.rs
+++ b/lib/deployer/src/aws/route.rs
@@ -306,10 +306,10 @@ fn find_throttling(
     }
 }
 
-async fn update_dns_record(auth: &Auth, domain: &str, cname: &str) {
+async fn update_dns_record(auth: &Auth, domain: &str, cname: &str, target_zone_id: Option<String>) {
     tracing::debug!("Associating domain {}", domain);
     let rclient = route53::make_client(auth).await;
-    route53::create_record_set(&rclient, domain, domain, "CNAME", cname).await;
+    route53::create_record_set(&rclient, domain, domain, "CNAME", cname, target_zone_id).await;
 }
 
 async fn find_or_create_cert(auth: &Auth, domain: &str, token: &str) -> String {
@@ -335,6 +335,7 @@ async fn find_or_create_cert(auth: &Auth, domain: &str, token: &str) -> String {
                 &rec.name,
                 &rec.r#type.as_str(),
                 &rec.value,
+                None
             )
             .await;
         }
@@ -362,8 +363,9 @@ pub async fn create_domain(
         let gateway_domain =
             gateway::create_or_update_domain(&client, api_id, &domain, &route.stage, &cert_arn, "")
                 .await;
+        let target_zone_id = gateway::find_hosted_zone(&client, &domain).await;
         println!("Updating dns record {}", &gateway_domain);
-        update_dns_record(auth, domain, &gateway_domain).await;
+        update_dns_record(auth, domain, &gateway_domain, target_zone_id).await;
     }
     maybe_domain
 }

--- a/lib/provider/src/aws/gateway.rs
+++ b/lib/provider/src/aws/gateway.rs
@@ -790,4 +790,24 @@ pub async fn get_tag(client: &Client, arn: &str, tag: String) -> String {
     }
 }
 
+pub async fn find_hosted_zone(client: &Client, domain_name: &str) -> Option<String> {
+    let res = client
+        .get_domain_name()
+        .domain_name(domain_name)
+        .send()
+        .await;
+    match res  {
+        Ok(r) => {
+            let xs = r.domain_name_configurations.unwrap().to_vec();
+            if let Some(item) = xs.first() {
+                item.hosted_zone_id.clone()
+            } else {
+                None
+            }
+        }
+        Err(_) => None
+    }
+}
+
+
 pub type GatewayCors = aws_sdk_apigatewayv2::types::Cors;

--- a/lib/provider/src/aws/route53.rs
+++ b/lib/provider/src/aws/route53.rs
@@ -48,17 +48,17 @@ fn make_record_set(vr: ValidationRecord) -> ResourceRecordSet {
         .unwrap()
 }
 
-fn make_alias_target(hosted_zone_id: &str, dns_name: &str) -> AliasTarget {
+fn make_alias_target(target_zone_id: &str, dns_name: &str) -> AliasTarget {
     let b = AliasTargetBuilder::default();
-    b.hosted_zone_id(hosted_zone_id)
+    b.hosted_zone_id(target_zone_id)
         .dns_name(dns_name)
         .build().unwrap()
 }
 
-fn make_alias_record_set(vr: ValidationRecord, hosted_zone_id: &str) -> ResourceRecordSet {
+fn make_alias_record_set(vr: ValidationRecord, target_zone_id: &str) -> ResourceRecordSet {
     let ValidationRecord { value, name, .. } = vr;
     let b = ResourceRecordSetBuilder::default();
-    let alias_target = make_alias_target(hosted_zone_id, &value);
+    let alias_target = make_alias_target(target_zone_id, &value);
     b.name(name)
         .r#type(RrType::from("A"))
         .alias_target(alias_target)
@@ -66,10 +66,10 @@ fn make_alias_record_set(vr: ValidationRecord, hosted_zone_id: &str) -> Resource
         .unwrap()
 }
 
-fn make_change(vr: ValidationRecord, hosted_zone_id: &str, root: bool) -> Change {
+fn make_change(vr: ValidationRecord, target_zone_id: &str, root: bool) -> Change {
     let b = ChangeBuilder::default();
     let record_set = if root {
-        make_alias_record_set(vr, hosted_zone_id)
+        make_alias_record_set(vr, target_zone_id)
     } else {
         make_record_set(vr)
     };
@@ -81,11 +81,20 @@ fn make_change(vr: ValidationRecord, hosted_zone_id: &str, root: bool) -> Change
 
 fn make_change_batch(
     vr: ValidationRecord,
-    hosted_zone_id: &str,
+    target_zone_id: Option<String>,
     root: bool
 ) -> ChangeBatch {
     let b = ChangeBatchBuilder::default();
-    let change = make_change(vr, hosted_zone_id, root);
+    let tz_id = if root {
+        match target_zone_id {
+            Some(t) => t,
+            None => panic!("No target_zone_id specified")
+        }
+    } else {
+        // non-root does not need tz_id
+        String::from("")
+    };
+    let change = make_change(vr, &tz_id, root);
     b.set_comment(None).changes(change).build().unwrap()
 }
 
@@ -106,12 +115,16 @@ async fn get_hosted_zone_id(client: &Client, name: &str) -> (Option<String>, boo
         format!("{}.", name)
     };
 
+    let fname = format!("{}.", name);
+
     let zones = list_hosted_zones(client).await;
     let maybe_hosted_zone = zones.get(&zname);
     let (maybe_id, is_root) = match maybe_hosted_zone {
-        Some(id) => (Some(id), true),
+        Some(id) => {
+            (Some(id), &fname == &zname)
+        }
         None => {
-            if let Some(id) = zones.get(&format!("{}.", name)) {
+            if let Some(id) = zones.get(&fname) {
                 (Some(id), true)
             } else {
                 (None, false)
@@ -129,14 +142,15 @@ async fn get_hosted_zone_id(client: &Client, name: &str) -> (Option<String>, boo
 
 pub async fn create_record_set(
     client: &Client,
-    domain: &str,
+    _domain: &str,
     name: &str,
     rtype: &str,
     value: &str,
+    target_zone_id: Option<String>,
 ) {
 
-    let (maybe_hosted_zone_id, root) = get_hosted_zone_id(client, domain).await;
-    println!("Creating Recordset {} {} {} {} root:{}", domain, name, rtype, value, root);
+    let (maybe_hosted_zone_id, root) = get_hosted_zone_id(client, name).await;
+    println!("Creating Recordset {} {} {} root:{}", name, rtype, value, root);
 
     if let Some(hosted_zone_id) = maybe_hosted_zone_id {
         let vr = ValidationRecord {
@@ -144,7 +158,7 @@ pub async fn create_record_set(
             rtype: RrType::from(rtype),
             value: value.to_string(),
         };
-        let change_batch = make_change_batch(vr, &hosted_zone_id, root);
+        let change_batch = make_change_batch(vr, target_zone_id, root);
         let _ = client
             .change_resource_record_sets()
             .hosted_zone_id(hosted_zone_id)

--- a/lib/provider/src/aws/route53.rs
+++ b/lib/provider/src/aws/route53.rs
@@ -8,9 +8,11 @@ use aws_sdk_route53::{
         ResourceRecord,
         ResourceRecordSet,
         RrType,
+        AliasTarget,
         builders::{
             ChangeBatchBuilder,
             ChangeBuilder,
+            AliasTargetBuilder,
             ResourceRecordBuilder,
             ResourceRecordSetBuilder,
         },
@@ -46,18 +48,44 @@ fn make_record_set(vr: ValidationRecord) -> ResourceRecordSet {
         .unwrap()
 }
 
-fn make_change(vr: ValidationRecord) -> Change {
+fn make_alias_target(hosted_zone_id: &str, dns_name: &str) -> AliasTarget {
+    let b = AliasTargetBuilder::default();
+    b.hosted_zone_id(hosted_zone_id)
+        .dns_name(dns_name)
+        .build().unwrap()
+}
+
+fn make_alias_record_set(vr: ValidationRecord, hosted_zone_id: &str) -> ResourceRecordSet {
+    let ValidationRecord { value, name, .. } = vr;
+    let b = ResourceRecordSetBuilder::default();
+    let alias_target = make_alias_target(hosted_zone_id, &value);
+    b.name(name)
+        .r#type(RrType::from("A"))
+        .alias_target(alias_target)
+        .build()
+        .unwrap()
+}
+
+fn make_change(vr: ValidationRecord, hosted_zone_id: &str, root: bool) -> Change {
     let b = ChangeBuilder::default();
-    let record_set = make_record_set(vr);
+    let record_set = if root {
+        make_alias_record_set(vr, hosted_zone_id)
+    } else {
+        make_record_set(vr)
+    };
     b.action(ChangeAction::Upsert)
         .resource_record_set(record_set)
         .build()
         .unwrap()
 }
 
-fn make_change_batch(vr: ValidationRecord) -> ChangeBatch {
+fn make_change_batch(
+    vr: ValidationRecord,
+    hosted_zone_id: &str,
+    root: bool
+) -> ChangeBatch {
     let b = ChangeBatchBuilder::default();
-    let change = make_change(vr);
+    let change = make_change(vr, hosted_zone_id, root);
     b.set_comment(None).changes(change).build().unwrap()
 }
 
@@ -71,21 +99,31 @@ async fn list_hosted_zones(client: &Client) -> HashMap<String, String> {
     h
 }
 
-async fn get_hosted_zone_id(client: &Client, name: &str) -> Option<String> {
+async fn get_hosted_zone_id(client: &Client, name: &str) -> (Option<String>, bool) {
     let zname = if let Some((_k, v)) = name.split_once(".") {
         format!("{}.", &v)
     } else {
-        panic!("Invalid domain. Can't get zone id")
+        format!("{}.", name)
     };
 
     let zones = list_hosted_zones(client).await;
-    let maybe_id = zones.get(&zname);
+    let maybe_hosted_zone = zones.get(&zname);
+    let (maybe_id, is_root) = match maybe_hosted_zone {
+        Some(id) => (Some(id), true),
+        None => {
+            if let Some(id) = zones.get(&format!("{}.", name)) {
+                (Some(id), true)
+            } else {
+                (None, false)
+            }
+        }
+    };
 
     if let Some(id) = maybe_id {
         let parts: Vec<&str> = id.split("/").collect();
-        parts.clone().last().cloned().map(String::from)
+        (parts.clone().last().cloned().map(String::from), is_root)
     } else {
-        None
+        (None, is_root)
     }
 }
 
@@ -96,8 +134,9 @@ pub async fn create_record_set(
     rtype: &str,
     value: &str,
 ) {
-    tracing::debug!("Creating Recordset {} {} {}", name, rtype, value);
-    let maybe_hosted_zone_id = get_hosted_zone_id(client, domain).await;
+
+    let (maybe_hosted_zone_id, root) = get_hosted_zone_id(client, domain).await;
+    println!("Creating Recordset {} {} {} {} root:{}", domain, name, rtype, value, root);
 
     if let Some(hosted_zone_id) = maybe_hosted_zone_id {
         let vr = ValidationRecord {
@@ -105,7 +144,7 @@ pub async fn create_record_set(
             rtype: RrType::from(rtype),
             value: value.to_string(),
         };
-        let change_batch = make_change_batch(vr);
+        let change_batch = make_change_batch(vr, &hosted_zone_id, root);
         let _ = client
             .change_resource_record_sets()
             .hosted_zone_id(hosted_zone_id)


### PR DESCRIPTION
For root domains, need to set alias with target zone id.
For non-root domains, set CNAME

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production DNS upsert behavior for custom domains; apex API Gateway mappings now require `target_zone_id` or deploy will panic, while page/CloudFront paths still pass `None` and may not get apex alias behavior.
> 
> **Overview**
> Fixes custom-domain DNS so **apex (root) hostnames** use Route53 **A alias** records toward API Gateway instead of invalid apex **CNAME** records.
> 
> `route53::create_record_set` now takes an optional `target_zone_id`, detects when the record name is the zone apex, and upserts an alias `A` record (using that hosted zone id) for roots while keeping TTL/CNAME-style records for subdomains. Hosted-zone resolution was extended so apex names map correctly and return a `root` flag.
> 
> API Gateway route deploy wires this through: **`find_hosted_zone`** reads the domain’s `hosted_zone_id` from API Gateway v2, and **`update_dns_record`** passes it into Route53. ACM validation and CloudFront page DNS callers pass `None` and stay on the non-alias path for those records.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9d5b3fbfab1d338fd16c7c02635d5dac7d50891. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->